### PR TITLE
Add missing step to migration guide

### DIFF
--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -404,7 +404,14 @@ Migration to paperless-ng is then performed in a few simple steps:
     ``docker-compose.env`` to your needs.
     See `docker route`_ for details on which edits are advised.
 
-6.  In order to find your existing documents with the new search feature, you need
+6.  Since ``docker-compose`` would just use the the old paperless image, we need to
+    manually build a new image:
+
+    .. code:: shell-session
+
+        $ docker-compose build
+
+7.  In order to find your existing documents with the new search feature, you need
     to invoke a one-time operation that will create the search index:
 
     .. code:: shell-session
@@ -414,7 +421,7 @@ Migration to paperless-ng is then performed in a few simple steps:
     This will migrate your database and create the search index. After that,
     paperless will take care of maintaining the index by itself.
 
-7.  Start paperless-ng.
+8.  Start paperless-ng.
 
     .. code:: bash
 
@@ -422,11 +429,11 @@ Migration to paperless-ng is then performed in a few simple steps:
 
     This will run paperless in the background and automatically start it on system boot.
 
-8.  Paperless installed a permanent redirect to ``admin/`` in your browser. This
+9.  Paperless installed a permanent redirect to ``admin/`` in your browser. This
     redirect is still in place and prevents access to the new UI. Clear
     browsing cache in order to fix this.
 
-9.  Optionally, follow the instructions below to migrate your existing data to PostgreSQL.
+10.  Optionally, follow the instructions below to migrate your existing data to PostgreSQL.
 
 
 .. _setup-sqlite_to_psql:


### PR DESCRIPTION
This was what happened when I tried to follow the steps:

```
$ docker-compose run --rm webserver document_index reindex 
Creating network "paperless_default" with the default driver
Pulling broker (redis:6.0)...
6.0: Pulling from library/redis
852e50cd189d: Pull complete
76190fa64fb8: Pull complete
9cbb1b61e01b: Pull complete
d048021f2aae: Pull complete
6f4b2af24926: Pull complete
1cf1d6922fba: Pull complete
Digest: sha256:5b98e32b58cdbf9f6b6f77072c4915d5ebec43912114031f37fa5fa25b032489
Status: Downloaded newer image for redis:6.0
Creating paperless_broker_1 ...
Creating paperless_broker_1 ... done
Operations to perform:
  Apply all migrations: admin, auth, contenttypes, documents, reminders, sessions
Running migrations:
  No migrations to apply.
Unknown command: 'document_index'
Type 'manage.py help' for usage.
```

As it turned out this tried to run the old paperless code. At least the version that I have here will only build an image if it doesn't exist yet. Since the name is the same, the old image matched.