### PR TITLE
Dockerfile: Add libqpdf-dev to build dependencies

### DIFF
--- a/docker/local/Dockerfile
+++ b/docker/local/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update \
 		libmagic-dev \
 		libpoppler-cpp-dev \
 		libpq-dev \
+		libqpdf-dev \
 		libxml2 \
 		optipng \
 		pngquant \
@@ -34,7 +35,7 @@ RUN apt-get update \
 		zlib1g \
 	&& pip3 install --upgrade supervisor setuptools \
 	&& pip install --no-cache-dir -r requirements.txt \
-	&& apt-get -y purge build-essential \
+	&& apt-get -y purge build-essential libqpdf-dev \
 	&& apt-get -y autoremove --purge \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& mkdir /var/log/supervisord /var/run/supervisord


### PR DESCRIPTION
#95 
The qpdf header files are necessary for building pikepdf from source.
The latter is necessary on aarch64, because no public wheels for this package on the ARM platforms exist.

I can confirm that `docker-compose build` and paperless-ng run successfully with this change on 
`$ uname -a
Linux ubuntu 5.8.0-1008-raspi #11-Ubuntu SMP PREEMPT Thu Nov 12 15:49:32 UTC 2020 aarch64 aarch64 aarch64 GNU/Linux
`
