### PR TITLE
Document list small card layout adjustments

### DIFF
--- a/src-ui/src/app/components/document-list/document-card-small/document-card-small.component.html
+++ b/src-ui/src/app/components/document-list/document-card-small/document-card-small.component.html
@@ -1,4 +1,4 @@
-<div class="col p-2 h-100" style="width: 16rem;">
+<div class="col p-2 h-100">
   <div class="card h-100 shadow-sm">
     <div class="border-bottom">
       <img class="card-img doc-img" [src]="getThumbUrl()">
@@ -22,7 +22,7 @@
     </div>
     <div class="card-footer">
 
-      <div class="d-flex justify-content-between align-items-center ml-n2">
+      <div class="d-flex justify-content-between align-items-center mx-n2">
         <div class="btn-group">
           <a routerLink="/documents/{{document.id}}" class="btn btn-sm btn-outline-secondary" title="Edit">
             <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-pencil" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
@@ -42,7 +42,7 @@
             </svg>
           </a>
         </div>
-        <small class="text-muted">{{document.created | date}}</small>
+        <small class="text-muted pl-1">{{document.created | date}}</small>
       </div>
 
     </div>

--- a/src-ui/src/app/components/document-list/document-list.component.html
+++ b/src-ui/src/app/components/document-list/document-list.component.html
@@ -116,6 +116,6 @@
 </table>
 
 
-<div class=" m-n2 row" *ngIf="displayMode == 'smallCards'">
+<div class="m-n2 row row row-cols-2 row-cols-md-3 row-cols-lg-4 row-cols-xl-5" *ngIf="displayMode == 'smallCards'">
   <app-document-card-small [document]="d" *ngFor="let d of list.documents" (clickTag)="clickTag($event)" (clickCorrespondent)="clickCorrespondent($event)"></app-document-card-small>
 </div>

--- a/src-ui/src/app/components/document-list/document-list.component.html
+++ b/src-ui/src/app/components/document-list/document-list.component.html
@@ -116,6 +116,6 @@
 </table>
 
 
-<div class="m-n2 row row row-cols-2 row-cols-md-3 row-cols-lg-4 row-cols-xl-5" *ngIf="displayMode == 'smallCards'">
+<div class="m-n2 row row-cols-paperless-cards" *ngIf="displayMode == 'smallCards'">
   <app-document-card-small [document]="d" *ngFor="let d of list.documents" (clickTag)="clickTag($event)" (clickCorrespondent)="clickCorrespondent($event)"></app-document-card-small>
 </div>

--- a/src-ui/src/app/components/document-list/document-list.component.scss
+++ b/src-ui/src/app/components/document-list/document-list.component.scss
@@ -1,0 +1,21 @@
+$paperless-card-breakpoints: (
+  0: 2, // xs
+  768px: 3, //md
+  992px: 4, //lg
+  1200px: 5, //xl
+  1400px: 6, // xxl
+  1600px: 7,
+  1800px: 8,
+  2000px: 9
+);
+
+.row-cols-paperless-cards {
+  @each $width, $n_cols in $paperless-card-breakpoints {
+    @media(min-width: $width) {
+      > * {
+        flex: 0 0 auto;
+        width: 100% / $n_cols;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Hi @jonaswinkler hope Im not annoying you with the PRs =) This very small one just tweaks the small card document list to keep it full width and the document cards evenly spaced, it just changes the bootstrap classes and I think looks a little cleaner. Screenshots below for reference!

Before:
<img width="387" alt="mobile_old" src="https://user-images.githubusercontent.com/4887959/102281759-61404680-3ee4-11eb-93f2-e3e167576a7a.png">
After:
<img width="362" alt="mobile_new" src="https://user-images.githubusercontent.com/4887959/102281770-64d3cd80-3ee4-11eb-85b6-396e6d2695e0.png">

Before:
<img width="876" alt="md_old" src="https://user-images.githubusercontent.com/4887959/102281791-6d2c0880-3ee4-11eb-89c9-4708eb1c6d2e.png">
After:
<img width="803" alt="md_new" src="https://user-images.githubusercontent.com/4887959/102281802-71582600-3ee4-11eb-98eb-ddfafb3396b9.png">

Before:
<img width="748" alt="lg_old" src="https://user-images.githubusercontent.com/4887959/102281814-77e69d80-3ee4-11eb-87f0-740208b561ab.png">
After:
<img width="730" alt="lg_new" src="https://user-images.githubusercontent.com/4887959/102281818-7ae18e00-3ee4-11eb-8014-f770a11f4e3c.png">

Before:
<img width="1007" alt="xl_old" src="https://user-images.githubusercontent.com/4887959/102282724-e5df9480-3ee5-11eb-9cab-2118bd3435d2.png">
After:
<img width="1008" alt="xl_new" src="https://user-images.githubusercontent.com/4887959/102282720-e2e4a400-3ee5-11eb-9087-e60307aa5f4a.png">
