### PR TITLE
Date dropdown clear buttons, keyboard support

### DIFF
--- a/src-ui/src/app/components/filter-editor/filter-dropdown-date/filter-dropdown-date.component.html
+++ b/src-ui/src/app/components/filter-editor/filter-dropdown-date/filter-dropdown-date.component.html
@@ -10,31 +10,6 @@
           <ng-container *ngIf="!isStringRange(range)"> days</ng-container>
         </button>
         <div class="list-group-item d-flex flex-column align-items-start" role="menuitem">
-          <form name="beforeForm" #beforeForm="ngForm">
-            <div class="mb-2 d-flex flex-row w-100 justify-content-between small">
-              <div>Before</div>
-              <a *ngIf="_dateBefore || dateBefore" class="btn btn-link p-0 m-0" (click)="clearBefore()">
-                <svg width="0.8em" height="0.8em" viewBox="0 0 16 16" class="bi bi-x" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-                  <path fill-rule="evenodd" d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708z" />
-                </svg>
-                <small>Clear</small>
-              </a>
-            </div>
-            <div class="input-group input-group-sm">
-              <input class="form-control" type="text" placeholder="yyyy-mm-dd" name="before" [(ngModel)]="_dateBefore" [maxDate]="this._maxDate" ngbDatepicker (dateSelect)="onBeforeSelected($event)" (keyup)="keyupBefore($event)" #beforeDatepicker="ngbDatepicker">
-              <div class="input-group-append">
-                <button class="btn btn-outline-secondary btn-sm" (click)="beforeDatepicker.toggle()" type="button">
-                  <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-calendar-date" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-                    <path fill-rule="evenodd" d="M3.5 0a.5.5 0 0 1 .5.5V1h8V.5a.5.5 0 0 1 1 0V1h1a2 2 0 0 1 2 2v11a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V3a2 2 0 0 1 2-2h1V.5a.5.5 0 0 1 .5-.5zM1 4v10a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V4H1z" />
-                    <path
-                      d="M6.445 11.688V6.354h-.633A12.6 12.6 0 0 0 4.5 7.16v.695c.375-.257.969-.62 1.258-.777h.012v4.61h.675zm1.188-1.305c.047.64.594 1.406 1.703 1.406 1.258 0 2-1.066 2-2.871 0-1.934-.781-2.668-1.953-2.668-.926 0-1.797.672-1.797 1.809 0 1.16.824 1.77 1.676 1.77.746 0 1.23-.376 1.383-.79h.027c-.004 1.316-.461 2.164-1.305 2.164-.664 0-1.008-.45-1.05-.82h-.684zm2.953-2.317c0 .696-.559 1.18-1.184 1.18-.601 0-1.144-.383-1.144-1.2 0-.823.582-1.21 1.168-1.21.633 0 1.16.398 1.16 1.23z" />
-                  </svg>
-                </button>
-              </div>
-            </div>
-          </form>
-        </div>
-        <div class="list-group-item d-flex flex-column align-items-start" role="menuitem">
           <form name="afterForm" #afterForm="ngForm">
             <div class="mb-2 d-flex flex-row w-100 justify-content-between small">
               <div>After</div>
@@ -49,6 +24,31 @@
               <input class="form-control form-control-sm" type="text" placeholder="yyyy-mm-dd" name="after" [(ngModel)]="_dateAfter" [maxDate]="this._maxDate" ngbDatepicker (dateSelect)="onAfterSelected($event)" (keyup)="keyupAfter($event)" #afterDatepicker="ngbDatepicker">
               <div class="input-group-append">
                 <button class="btn btn-outline-secondary btn-sm" (click)="afterDatepicker.toggle()" type="button">
+                  <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-calendar-date" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                    <path fill-rule="evenodd" d="M3.5 0a.5.5 0 0 1 .5.5V1h8V.5a.5.5 0 0 1 1 0V1h1a2 2 0 0 1 2 2v11a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V3a2 2 0 0 1 2-2h1V.5a.5.5 0 0 1 .5-.5zM1 4v10a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V4H1z" />
+                    <path
+                      d="M6.445 11.688V6.354h-.633A12.6 12.6 0 0 0 4.5 7.16v.695c.375-.257.969-.62 1.258-.777h.012v4.61h.675zm1.188-1.305c.047.64.594 1.406 1.703 1.406 1.258 0 2-1.066 2-2.871 0-1.934-.781-2.668-1.953-2.668-.926 0-1.797.672-1.797 1.809 0 1.16.824 1.77 1.676 1.77.746 0 1.23-.376 1.383-.79h.027c-.004 1.316-.461 2.164-1.305 2.164-.664 0-1.008-.45-1.05-.82h-.684zm2.953-2.317c0 .696-.559 1.18-1.184 1.18-.601 0-1.144-.383-1.144-1.2 0-.823.582-1.21 1.168-1.21.633 0 1.16.398 1.16 1.23z" />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </form>
+        </div>
+        <div class="list-group-item d-flex flex-column align-items-start" role="menuitem">
+          <form name="beforeForm" #beforeForm="ngForm">
+            <div class="mb-2 d-flex flex-row w-100 justify-content-between small">
+              <div>Before</div>
+              <a *ngIf="_dateBefore || dateBefore" class="btn btn-link p-0 m-0" (click)="clearBefore()">
+                <svg width="0.8em" height="0.8em" viewBox="0 0 16 16" class="bi bi-x" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                  <path fill-rule="evenodd" d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708z" />
+                </svg>
+                <small>Clear</small>
+              </a>
+            </div>
+            <div class="input-group input-group-sm">
+              <input class="form-control" type="text" placeholder="yyyy-mm-dd" name="before" [(ngModel)]="_dateBefore" [maxDate]="this._maxDate" ngbDatepicker (dateSelect)="onBeforeSelected($event)" (keyup)="keyupBefore($event)" #beforeDatepicker="ngbDatepicker">
+              <div class="input-group-append">
+                <button class="btn btn-outline-secondary btn-sm" (click)="beforeDatepicker.toggle()" type="button">
                   <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-calendar-date" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
                     <path fill-rule="evenodd" d="M3.5 0a.5.5 0 0 1 .5.5V1h8V.5a.5.5 0 0 1 1 0V1h1a2 2 0 0 1 2 2v11a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V3a2 2 0 0 1 2-2h1V.5a.5.5 0 0 1 .5-.5zM1 4v10a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V4H1z" />
                     <path

--- a/src-ui/src/app/components/filter-editor/filter-dropdown-date/filter-dropdown-date.component.html
+++ b/src-ui/src/app/components/filter-editor/filter-dropdown-date/filter-dropdown-date.component.html
@@ -4,14 +4,21 @@
   </button>
   <div class="dropdown-menu date-filter shadow pt-0" ngbDropdownMenu attr.aria-labelledby="dropdown{{title}}">
     <div class="list-group list-group-flush">
-        <button class="list-group-item small list-goup list-group-item-action d-flex p-2 pl-3" (click)="clear()">Clear</button>
         <button *ngFor="let range of [7, 30, 'month', 'year']" class="list-group-item small list-goup list-group-item-action d-flex p-2 pl-3" role="menuitem" (click)="setDateQuickFilter(range)">
           <ng-container *ngIf="isStringRange(range)">This </ng-container>
           {{ range }}
           <ng-container *ngIf="!isStringRange(range)"> days</ng-container>
         </button>
         <div class="list-group-item d-flex flex-column align-items-start" role="menuitem">
-          <div>Before</div>
+          <div class="mb-2 d-flex flex-row w-100 justify-content-between small">
+            <div>Before</div>
+            <a *ngIf="_dateBefore || dateBefore" class="btn btn-link p-0 m-0" (click)="clearBefore()">
+              <svg width="0.8em" height="0.8em" viewBox="0 0 16 16" class="bi bi-x" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                <path fill-rule="evenodd" d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708z"/>
+              </svg>
+              <small>Clear</small>
+            </a>
+          </div>
           <div class="input-group input-group-sm">
             <input class="form-control" type="text" placeholder="yyyy-mm-dd" name="before" [(ngModel)]="_dateBefore" [maxDate]="this._maxDate" ngbDatepicker (dateSelect)="onBeforeSelected($event)" #dpBefore="ngbDatepicker">
             <div class="input-group-append">
@@ -25,7 +32,15 @@
           </div>
         </div>
         <div class="list-group-item d-flex flex-column align-items-start" role="menuitem">
-          <div>After</div>
+          <div class="mb-2 d-flex flex-row w-100 justify-content-between small">
+            <div>After</div>
+            <a *ngIf="_dateAfter || dateAfter" class="btn btn-link p-0 m-0" (click)="clearAfter()">
+              <svg width="0.8em" height="0.8em" viewBox="0 0 16 16" class="bi bi-x" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                <path fill-rule="evenodd" d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708z"/>
+              </svg>
+              <small>Clear</small>
+            </a>
+          </div>
           <div class="input-group input-group-sm">
             <input class="form-control form-control-sm" type="text" placeholder="yyyy-mm-dd" name="after" [(ngModel)]="_dateAfter" [maxDate]="this._maxDate" ngbDatepicker (dateSelect)="onAfterSelected($event)" #dpAfter="ngbDatepicker">
             <div class="input-group-append">

--- a/src-ui/src/app/components/filter-editor/filter-dropdown-date/filter-dropdown-date.component.html
+++ b/src-ui/src/app/components/filter-editor/filter-dropdown-date/filter-dropdown-date.component.html
@@ -1,4 +1,4 @@
-  <div class="btn-group" ngbDropdown role="group" #filterDateDropdown="ngbDropdown">
+  <div class="btn-group" ngbDropdown role="group" #filterDateDropdown="ngbDropdown" (openChange)="dropdownOpenChange($event)">
     <button class="btn btn-sm" id="dropdown{{title}}" ngbDropdownToggle [ngClass]="dateBefore || dateAfter ? 'btn-primary' : 'btn-outline-primary'">
       {{title}}
     </button>
@@ -21,7 +21,7 @@
               </a>
             </div>
             <div class="input-group input-group-sm">
-              <input class="form-control form-control-sm" type="text" placeholder="yyyy-mm-dd" name="after" [(ngModel)]="_dateAfter" [maxDate]="this._maxDate" ngbDatepicker (dateSelect)="onAfterSelected($event)" (keyup)="keyupAfter($event)" #afterDatepicker="ngbDatepicker">
+              <input class="form-control form-control-sm" type="text" placeholder="yyyy-mm-dd" name="after" [(ngModel)]="_dateAfter" [maxDate]="_maxDate" ngbDatepicker (dateSelect)="onAfterSelected($event)" (keyup)="keyupAfter($event)" (focus)="_afterHasFocus = true" (blur)="_afterHasFocus = false" #afterDatepicker="ngbDatepicker">
               <div class="input-group-append">
                 <button class="btn btn-outline-secondary btn-sm" (click)="afterDatepicker.toggle()" type="button">
                   <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-calendar-date" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
@@ -46,7 +46,7 @@
               </a>
             </div>
             <div class="input-group input-group-sm">
-              <input class="form-control" type="text" placeholder="yyyy-mm-dd" name="before" [(ngModel)]="_dateBefore" [maxDate]="this._maxDate" ngbDatepicker (dateSelect)="onBeforeSelected($event)" (keyup)="keyupBefore($event)" #beforeDatepicker="ngbDatepicker">
+              <input class="form-control" type="text" placeholder="yyyy-mm-dd" name="before" [(ngModel)]="_dateBefore" [maxDate]="_maxDate" ngbDatepicker (dateSelect)="onBeforeSelected($event)" (keyup)="keyupBefore($event)" (focus)="_beforeHasFocus = true" (blur)="_beforeHasFocus = false" #beforeDatepicker="ngbDatepicker">
               <div class="input-group-append">
                 <button class="btn btn-outline-secondary btn-sm" (click)="beforeDatepicker.toggle()" type="button">
                   <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-calendar-date" fill="currentColor" xmlns="http://www.w3.org/2000/svg">

--- a/src-ui/src/app/components/filter-editor/filter-dropdown-date/filter-dropdown-date.component.html
+++ b/src-ui/src/app/components/filter-editor/filter-dropdown-date/filter-dropdown-date.component.html
@@ -1,58 +1,64 @@
-  <div class="btn-group" ngbDropdown role="group">
-  <button class="btn btn-sm" id="dropdown{{title}}" ngbDropdownToggle [ngClass]="dateBefore || dateAfter ? 'btn-primary' : 'btn-outline-primary'">
-    {{title}}
-  </button>
-  <div class="dropdown-menu date-filter shadow pt-0" ngbDropdownMenu attr.aria-labelledby="dropdown{{title}}">
-    <div class="list-group list-group-flush">
+  <div class="btn-group" ngbDropdown role="group" #filterDateDropdown="ngbDropdown">
+    <button class="btn btn-sm" id="dropdown{{title}}" ngbDropdownToggle [ngClass]="dateBefore || dateAfter ? 'btn-primary' : 'btn-outline-primary'">
+      {{title}}
+    </button>
+    <div class="dropdown-menu date-filter shadow pt-0" ngbDropdownMenu attr.aria-labelledby="dropdown{{title}}">
+      <div class="list-group list-group-flush">
         <button *ngFor="let range of [7, 30, 'month', 'year']" class="list-group-item small list-goup list-group-item-action d-flex p-2 pl-3" role="menuitem" (click)="setDateQuickFilter(range)">
           <ng-container *ngIf="isStringRange(range)">This </ng-container>
           {{ range }}
           <ng-container *ngIf="!isStringRange(range)"> days</ng-container>
         </button>
         <div class="list-group-item d-flex flex-column align-items-start" role="menuitem">
-          <div class="mb-2 d-flex flex-row w-100 justify-content-between small">
-            <div>Before</div>
-            <a *ngIf="_dateBefore || dateBefore" class="btn btn-link p-0 m-0" (click)="clearBefore()">
-              <svg width="0.8em" height="0.8em" viewBox="0 0 16 16" class="bi bi-x" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-                <path fill-rule="evenodd" d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708z"/>
-              </svg>
-              <small>Clear</small>
-            </a>
-          </div>
-          <div class="input-group input-group-sm">
-            <input class="form-control" type="text" placeholder="yyyy-mm-dd" name="before" [(ngModel)]="_dateBefore" [maxDate]="this._maxDate" ngbDatepicker (dateSelect)="onBeforeSelected($event)" #dpBefore="ngbDatepicker">
-            <div class="input-group-append">
-              <button class="btn btn-outline-secondary btn-sm" (click)="dpBefore.toggle()" type="button">
-                <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-calendar-date" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-                  <path fill-rule="evenodd" d="M3.5 0a.5.5 0 0 1 .5.5V1h8V.5a.5.5 0 0 1 1 0V1h1a2 2 0 0 1 2 2v11a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V3a2 2 0 0 1 2-2h1V.5a.5.5 0 0 1 .5-.5zM1 4v10a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V4H1z"/>
-                  <path d="M6.445 11.688V6.354h-.633A12.6 12.6 0 0 0 4.5 7.16v.695c.375-.257.969-.62 1.258-.777h.012v4.61h.675zm1.188-1.305c.047.64.594 1.406 1.703 1.406 1.258 0 2-1.066 2-2.871 0-1.934-.781-2.668-1.953-2.668-.926 0-1.797.672-1.797 1.809 0 1.16.824 1.77 1.676 1.77.746 0 1.23-.376 1.383-.79h.027c-.004 1.316-.461 2.164-1.305 2.164-.664 0-1.008-.45-1.05-.82h-.684zm2.953-2.317c0 .696-.559 1.18-1.184 1.18-.601 0-1.144-.383-1.144-1.2 0-.823.582-1.21 1.168-1.21.633 0 1.16.398 1.16 1.23z"/>
+          <form name="beforeForm" #beforeForm="ngForm">
+            <div class="mb-2 d-flex flex-row w-100 justify-content-between small">
+              <div>Before</div>
+              <a *ngIf="_dateBefore || dateBefore" class="btn btn-link p-0 m-0" (click)="clearBefore()">
+                <svg width="0.8em" height="0.8em" viewBox="0 0 16 16" class="bi bi-x" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                  <path fill-rule="evenodd" d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708z" />
                 </svg>
-              </button>
+                <small>Clear</small>
+              </a>
             </div>
-          </div>
+            <div class="input-group input-group-sm">
+              <input class="form-control" type="text" placeholder="yyyy-mm-dd" name="before" [(ngModel)]="_dateBefore" [maxDate]="this._maxDate" ngbDatepicker (dateSelect)="onBeforeSelected($event)" (keyup)="keyupBefore($event)" #beforeDatepicker="ngbDatepicker">
+              <div class="input-group-append">
+                <button class="btn btn-outline-secondary btn-sm" (click)="beforeDatepicker.toggle()" type="button">
+                  <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-calendar-date" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                    <path fill-rule="evenodd" d="M3.5 0a.5.5 0 0 1 .5.5V1h8V.5a.5.5 0 0 1 1 0V1h1a2 2 0 0 1 2 2v11a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V3a2 2 0 0 1 2-2h1V.5a.5.5 0 0 1 .5-.5zM1 4v10a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V4H1z" />
+                    <path
+                      d="M6.445 11.688V6.354h-.633A12.6 12.6 0 0 0 4.5 7.16v.695c.375-.257.969-.62 1.258-.777h.012v4.61h.675zm1.188-1.305c.047.64.594 1.406 1.703 1.406 1.258 0 2-1.066 2-2.871 0-1.934-.781-2.668-1.953-2.668-.926 0-1.797.672-1.797 1.809 0 1.16.824 1.77 1.676 1.77.746 0 1.23-.376 1.383-.79h.027c-.004 1.316-.461 2.164-1.305 2.164-.664 0-1.008-.45-1.05-.82h-.684zm2.953-2.317c0 .696-.559 1.18-1.184 1.18-.601 0-1.144-.383-1.144-1.2 0-.823.582-1.21 1.168-1.21.633 0 1.16.398 1.16 1.23z" />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </form>
         </div>
         <div class="list-group-item d-flex flex-column align-items-start" role="menuitem">
-          <div class="mb-2 d-flex flex-row w-100 justify-content-between small">
-            <div>After</div>
-            <a *ngIf="_dateAfter || dateAfter" class="btn btn-link p-0 m-0" (click)="clearAfter()">
-              <svg width="0.8em" height="0.8em" viewBox="0 0 16 16" class="bi bi-x" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-                <path fill-rule="evenodd" d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708z"/>
-              </svg>
-              <small>Clear</small>
-            </a>
-          </div>
-          <div class="input-group input-group-sm">
-            <input class="form-control form-control-sm" type="text" placeholder="yyyy-mm-dd" name="after" [(ngModel)]="_dateAfter" [maxDate]="this._maxDate" ngbDatepicker (dateSelect)="onAfterSelected($event)" #dpAfter="ngbDatepicker">
-            <div class="input-group-append">
-              <button class="btn btn-outline-secondary btn-sm" (click)="dpAfter.toggle()" type="button">
-                <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-calendar-date" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-                  <path fill-rule="evenodd" d="M3.5 0a.5.5 0 0 1 .5.5V1h8V.5a.5.5 0 0 1 1 0V1h1a2 2 0 0 1 2 2v11a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V3a2 2 0 0 1 2-2h1V.5a.5.5 0 0 1 .5-.5zM1 4v10a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V4H1z"/>
-                  <path d="M6.445 11.688V6.354h-.633A12.6 12.6 0 0 0 4.5 7.16v.695c.375-.257.969-.62 1.258-.777h.012v4.61h.675zm1.188-1.305c.047.64.594 1.406 1.703 1.406 1.258 0 2-1.066 2-2.871 0-1.934-.781-2.668-1.953-2.668-.926 0-1.797.672-1.797 1.809 0 1.16.824 1.77 1.676 1.77.746 0 1.23-.376 1.383-.79h.027c-.004 1.316-.461 2.164-1.305 2.164-.664 0-1.008-.45-1.05-.82h-.684zm2.953-2.317c0 .696-.559 1.18-1.184 1.18-.601 0-1.144-.383-1.144-1.2 0-.823.582-1.21 1.168-1.21.633 0 1.16.398 1.16 1.23z"/>
+          <form name="afterForm" #afterForm="ngForm">
+            <div class="mb-2 d-flex flex-row w-100 justify-content-between small">
+              <div>After</div>
+              <a *ngIf="_dateAfter || dateAfter" class="btn btn-link p-0 m-0" (click)="clearAfter()">
+                <svg width="0.8em" height="0.8em" viewBox="0 0 16 16" class="bi bi-x" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                  <path fill-rule="evenodd" d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708z" />
                 </svg>
-              </button>
+                <small>Clear</small>
+              </a>
             </div>
-          </div>
+            <div class="input-group input-group-sm">
+              <input class="form-control form-control-sm" type="text" placeholder="yyyy-mm-dd" name="after" [(ngModel)]="_dateAfter" [maxDate]="this._maxDate" ngbDatepicker (dateSelect)="onAfterSelected($event)" (keyup)="keyupAfter($event)" #afterDatepicker="ngbDatepicker">
+              <div class="input-group-append">
+                <button class="btn btn-outline-secondary btn-sm" (click)="afterDatepicker.toggle()" type="button">
+                  <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-calendar-date" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                    <path fill-rule="evenodd" d="M3.5 0a.5.5 0 0 1 .5.5V1h8V.5a.5.5 0 0 1 1 0V1h1a2 2 0 0 1 2 2v11a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V3a2 2 0 0 1 2-2h1V.5a.5.5 0 0 1 .5-.5zM1 4v10a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V4H1z" />
+                    <path
+                      d="M6.445 11.688V6.354h-.633A12.6 12.6 0 0 0 4.5 7.16v.695c.375-.257.969-.62 1.258-.777h.012v4.61h.675zm1.188-1.305c.047.64.594 1.406 1.703 1.406 1.258 0 2-1.066 2-2.871 0-1.934-.781-2.668-1.953-2.668-.926 0-1.797.672-1.797 1.809 0 1.16.824 1.77 1.676 1.77.746 0 1.23-.376 1.383-.79h.027c-.004 1.316-.461 2.164-1.305 2.164-.664 0-1.008-.45-1.05-.82h-.684zm2.953-2.317c0 .696-.559 1.18-1.184 1.18-.601 0-1.144-.383-1.144-1.2 0-.823.582-1.21 1.168-1.21.633 0 1.16.398 1.16 1.23z" />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </form>
         </div>
+      </div>
     </div>
   </div>
-</div>

--- a/src-ui/src/app/components/filter-editor/filter-dropdown-date/filter-dropdown-date.component.html
+++ b/src-ui/src/app/components/filter-editor/filter-dropdown-date/filter-dropdown-date.component.html
@@ -21,7 +21,7 @@
               </a>
             </div>
             <div class="input-group input-group-sm">
-              <input class="form-control form-control-sm" type="text" placeholder="yyyy-mm-dd" name="after" [(ngModel)]="_dateAfter" [maxDate]="_maxDate" ngbDatepicker (dateSelect)="onAfterSelected($event)" (keyup)="keyupAfter($event)" (focus)="_afterHasFocus = true" (blur)="_afterHasFocus = false" #afterDatepicker="ngbDatepicker">
+              <input class="form-control form-control-sm" [ngClass]="{ 'is-invalid': !afterForm.valid }" type="text" placeholder="yyyy-mm-dd" name="after" [(ngModel)]="_dateAfter" [maxDate]="_maxDate" ngbDatepicker (dateSelect)="onAfterSelected($event)" (keyup)="keyupAfter($event)" (focus)="_afterHasFocus = true" (blur)="_afterHasFocus = false" #afterDatepicker="ngbDatepicker">
               <div class="input-group-append">
                 <button class="btn btn-outline-secondary btn-sm" (click)="afterDatepicker.toggle()" type="button">
                   <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-calendar-date" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
@@ -46,7 +46,7 @@
               </a>
             </div>
             <div class="input-group input-group-sm">
-              <input class="form-control" type="text" placeholder="yyyy-mm-dd" name="before" [(ngModel)]="_dateBefore" [maxDate]="_maxDate" ngbDatepicker (dateSelect)="onBeforeSelected($event)" (keyup)="keyupBefore($event)" (focus)="_beforeHasFocus = true" (blur)="_beforeHasFocus = false" #beforeDatepicker="ngbDatepicker">
+              <input class="form-control form-control-sm" [ngClass]="{ 'is-invalid': !beforeForm.valid }" type="text" placeholder="yyyy-mm-dd" name="before" [(ngModel)]="_dateBefore" [maxDate]="_maxDate" ngbDatepicker (dateSelect)="onBeforeSelected($event)" (keyup)="keyupBefore($event)" (focus)="_beforeHasFocus = true" (blur)="_beforeHasFocus = false" #beforeDatepicker="ngbDatepicker">
               <div class="input-group-append">
                 <button class="btn btn-outline-secondary btn-sm" (click)="beforeDatepicker.toggle()" type="button">
                   <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-calendar-date" fill="currentColor" xmlns="http://www.w3.org/2000/svg">

--- a/src-ui/src/app/components/filter-editor/filter-dropdown-date/filter-dropdown-date.component.ts
+++ b/src-ui/src/app/components/filter-editor/filter-dropdown-date/filter-dropdown-date.component.ts
@@ -141,8 +141,17 @@ export class FilterDropdownDateComponent {
 
   dropdownOpenChange(opened) {
     if (!opened) {
+      let dateSelection: DateSelection = {}
+
+      // clear date if invalid
       if (!this.afterForm.valid) this._dateAfter = this.dateAfter
+      else dateSelection.after = this._dateAfter
+
       if (!this.beforeForm.valid) this._dateBefore = this.dateBefore
+      else dateSelection.before = this._dateBefore
+
+      // apply the date if it is valid
+      if (this.afterForm.valid || this.beforeForm.valid) this.datesSet.emit(dateSelection)
     }
   }
 }

--- a/src-ui/src/app/components/filter-editor/filter-dropdown-date/filter-dropdown-date.component.ts
+++ b/src-ui/src/app/components/filter-editor/filter-dropdown-date/filter-dropdown-date.component.ts
@@ -129,8 +129,13 @@ export class FilterDropdownDateComponent {
   }
 
   keyupBefore(event: KeyboardEvent) {
-    if (event.key == 'Enter' && this.beforeForm.valid && typeof this._dateBefore !== 'string') {
-      this.datesSet.emit({before: this._dateBefore})
+    if (event.key == 'Enter') {
+      if (this.beforeForm.valid && typeof this._dateBefore !== 'string') {
+
+        this.datesSet.emit({before: this._dateBefore})
+      } else if (!this.beforeForm.valid) {
+        this.beforeDatepicker
+      }
     }
   }
 

--- a/src-ui/src/app/components/filter-editor/filter-dropdown-date/filter-dropdown-date.component.ts
+++ b/src-ui/src/app/components/filter-editor/filter-dropdown-date/filter-dropdown-date.component.ts
@@ -73,7 +73,9 @@ export class FilterDropdownDateComponent {
         beforeDatepickerElRef.nativeElement.value = dateString
       } else {
         afterDatepickerElRef.nativeElement.value = dateString
+        this._dateAfter = null
         beforeDatepickerElRef.nativeElement.value = dateString
+        this._dateBefore = null
       }
     }
   }

--- a/src-ui/src/app/components/filter-editor/filter-dropdown-date/filter-dropdown-date.component.ts
+++ b/src-ui/src/app/components/filter-editor/filter-dropdown-date/filter-dropdown-date.component.ts
@@ -104,9 +104,13 @@ export class FilterDropdownDateComponent {
     this.datesSet.emit({after: date, before: this._dateBefore})
   }
 
-  clear() {
+  clearBefore() {
     this._dateBefore = null
+    this.datesSet.emit({before: null})
+  }
+
+  clearAfter() {
     this._dateAfter = null
-    this.datesSet.emit({after: null, before: null})
+    this.datesSet.emit({after: null})
   }
 }

--- a/src-ui/src/app/components/filter-editor/filter-dropdown-date/filter-dropdown-date.component.ts
+++ b/src-ui/src/app/components/filter-editor/filter-dropdown-date/filter-dropdown-date.component.ts
@@ -7,7 +7,6 @@ export interface DateSelection {
   after?: NgbDateStruct
 }
 
-
 @Component({
   selector: 'app-filter-dropdown-date',
   templateUrl: './filter-dropdown-date.component.html',
@@ -100,12 +99,12 @@ export class FilterDropdownDateComponent {
 
   onBeforeSelected(date: NgbDateStruct) {
     this._dateBefore = date
-    this.datesSet.emit({after: this._dateAfter, before: date})
+    this.datesSet.emit({before: date})
   }
 
   onAfterSelected(date: NgbDateStruct) {
     this._dateAfter = date
-    this.datesSet.emit({after: date, before: this._dateBefore})
+    this.datesSet.emit({after: date})
   }
 
   clearBefore() {

--- a/src-ui/src/app/components/filter-editor/filter-dropdown-date/filter-dropdown-date.component.ts
+++ b/src-ui/src/app/components/filter-editor/filter-dropdown-date/filter-dropdown-date.component.ts
@@ -1,5 +1,6 @@
 import { Component, EventEmitter, Input, Output, ElementRef, ViewChild, SimpleChange } from '@angular/core';
-import { NgbDate, NgbDateStruct, NgbDatepicker } from '@ng-bootstrap/ng-bootstrap';
+import { NgForm } from '@angular/forms';
+import { NgbDropdown, NgbDate, NgbDateStruct, NgbDatepicker } from '@ng-bootstrap/ng-bootstrap';
 
 export interface DateSelection {
   before?: NgbDateStruct
@@ -26,8 +27,11 @@ export class FilterDropdownDateComponent {
   @Output()
   datesSet = new EventEmitter<DateSelection>()
 
-  @ViewChild('dpAfter') dpAfter: NgbDatepicker
-  @ViewChild('dpBefore') dpBefore: NgbDatepicker
+  @ViewChild('filterDateDropdown') filterDateDropdown: NgbDropdown
+  @ViewChild('beforeForm') beforeForm: NgForm
+  @ViewChild('afterForm') afterForm: NgForm
+  @ViewChild('beforeDatepicker') beforeDatepicker: NgbDatepicker
+  @ViewChild('afterDatepicker') afterDatepicker: NgbDatepicker
 
   _dateBefore: NgbDateStruct
   _dateAfter: NgbDateStruct
@@ -51,21 +55,21 @@ export class FilterDropdownDateComponent {
       dateBeforeChange = changes['dateBefore']
     }
 
-    if (this.dpBefore && this.dpAfter) {
-      let dpAfterElRef: ElementRef = this.dpAfter['_elRef']
-      let dpBeforeElRef: ElementRef = this.dpBefore['_elRef']
+    if (this.beforeDatepicker && this.afterDatepicker) {
+      let afterDatepickerElRef: ElementRef = this.afterDatepicker['_elRef']
+      let beforeDatepickerElRef: ElementRef = this.beforeDatepicker['_elRef']
 
       if (dateAfterChange && dateAfterChange.currentValue) {
         let dateAfterDate = dateAfterChange.currentValue as NgbDateStruct
         dateString = `${dateAfterDate.year}-${dateAfterDate.month.toString().padStart(2,'0')}-${dateAfterDate.day.toString().padStart(2,'0')}`
-        dpAfterElRef.nativeElement.value = dateString
+        afterDatepickerElRef.nativeElement.value = dateString
       } else if (dateBeforeChange && dateBeforeChange.currentValue) {
         let dateBeforeDate = dateBeforeChange.currentValue as NgbDateStruct
         dateString = `${dateBeforeDate.year}-${dateBeforeDate.month.toString().padStart(2,'0')}-${dateBeforeDate.day.toString().padStart(2,'0')}`
-        dpBeforeElRef.nativeElement.value = dateString
+        beforeDatepickerElRef.nativeElement.value = dateString
       } else {
-        dpAfterElRef.nativeElement.value = dateString
-        dpBeforeElRef.nativeElement.value = dateString
+        afterDatepickerElRef.nativeElement.value = dateString
+        beforeDatepickerElRef.nativeElement.value = dateString
       }
     }
   }
@@ -112,5 +116,25 @@ export class FilterDropdownDateComponent {
   clearAfter() {
     this._dateAfter = null
     this.datesSet.emit({after: null})
+  }
+
+  keyupAfter(event: KeyboardEvent) {
+    if (event.key == 'Enter') {
+      this.filterDateDropdown.close()
+    }
+
+    if (this.afterForm.valid && typeof this._dateAfter !== 'string') {
+      this.datesSet.emit({after: this._dateAfter})
+    }
+  }
+
+  keyupBefore(event: KeyboardEvent) {
+    if (event.key == 'Enter') {
+      this.filterDateDropdown.close()
+    }
+
+    if (this.beforeForm.valid && typeof this._dateBefore !== 'string') {
+      this.datesSet.emit({before: this._dateBefore})
+    }
   }
 }

--- a/src-ui/src/app/components/filter-editor/filter-dropdown-date/filter-dropdown-date.component.ts
+++ b/src-ui/src/app/components/filter-editor/filter-dropdown-date/filter-dropdown-date.component.ts
@@ -35,6 +35,9 @@ export class FilterDropdownDateComponent {
   _dateBefore: NgbDateStruct
   _dateAfter: NgbDateStruct
 
+  _afterHasFocus: boolean = false
+  _beforeHasFocus: boolean = false
+
   get _maxDate(): NgbDate {
     let date = new Date()
     return NgbDate.from({year: date.getFullYear(), month: date.getMonth() + 1, day: date.getDate()})
@@ -59,10 +62,12 @@ export class FilterDropdownDateComponent {
       let beforeDatepickerElRef: ElementRef = this.beforeDatepicker['_elRef']
 
       if (dateAfterChange && dateAfterChange.currentValue) {
+        if (this._afterHasFocus) return
         let dateAfterDate = dateAfterChange.currentValue as NgbDateStruct
         dateString = `${dateAfterDate.year}-${dateAfterDate.month.toString().padStart(2,'0')}-${dateAfterDate.day.toString().padStart(2,'0')}`
         afterDatepickerElRef.nativeElement.value = dateString
       } else if (dateBeforeChange && dateBeforeChange.currentValue) {
+        if (this._beforeHasFocus) return
         let dateBeforeDate = dateBeforeChange.currentValue as NgbDateStruct
         dateString = `${dateBeforeDate.year}-${dateBeforeDate.month.toString().padStart(2,'0')}-${dateBeforeDate.day.toString().padStart(2,'0')}`
         beforeDatepickerElRef.nativeElement.value = dateString
@@ -118,22 +123,21 @@ export class FilterDropdownDateComponent {
   }
 
   keyupAfter(event: KeyboardEvent) {
-    if (event.key == 'Enter') {
-      this.filterDateDropdown.close()
-    }
-
-    if (this.afterForm.valid && typeof this._dateAfter !== 'string') {
+    if (event.key == 'Enter' && this.afterForm.valid && typeof this._dateAfter !== 'string') {
       this.datesSet.emit({after: this._dateAfter})
     }
   }
 
   keyupBefore(event: KeyboardEvent) {
-    if (event.key == 'Enter') {
-      this.filterDateDropdown.close()
-    }
-
-    if (this.beforeForm.valid && typeof this._dateBefore !== 'string') {
+    if (event.key == 'Enter' && this.beforeForm.valid && typeof this._dateBefore !== 'string') {
       this.datesSet.emit({before: this._dateBefore})
+    }
+  }
+
+  dropdownOpenChange(opened) {
+    if (!opened) {
+      if (!this.afterForm.valid) this._dateAfter = this.dateAfter
+      if (!this.beforeForm.valid) this._dateBefore = this.dateBefore
     }
   }
 }

--- a/src-ui/src/app/components/filter-editor/filter-editor.component.ts
+++ b/src-ui/src/app/components/filter-editor/filter-editor.component.ts
@@ -25,13 +25,13 @@ export class FilterEditorComponent implements OnInit, OnDestroy {
       switch (this.filterRules[0].rule_type) {
 
         case FILTER_CORRESPONDENT:
-          return `Correspondent: ${this.correspondents.find(c => c.id == +rule.value) ?.name}`
+          return `Correspondent: ${this.correspondents.find(c => c.id == +rule.value)?.name}`
 
         case FILTER_DOCUMENT_TYPE:
-          return `Type: ${this.documentTypes.find(dt => dt.id == +rule.value) ?.name}`
+          return `Type: ${this.documentTypes.find(dt => dt.id == +rule.value)?.name}`
 
         case FILTER_HAS_TAG:
-          return `Tag: ${this.tags.find(t => t.id == +rule.value) ?.name}`
+          return `Tag: ${this.tags.find(t => t.id == +rule.value)?.name}`
 
       }
     }
@@ -62,22 +62,22 @@ export class FilterEditorComponent implements OnInit, OnDestroy {
 
   get selectedTags(): PaperlessTag[] {
     let tagRules: FilterRule[] = this.filterRules.filter(fr => fr.rule_type == FILTER_HAS_TAG)
-    return this.tags ?.filter(t => tagRules.find(tr => +tr.value == t.id))
+    return this.tags?.filter(t => tagRules.find(tr => +tr.value == t.id))
   }
 
   get selectedCorrespondents(): PaperlessCorrespondent[] {
     let correspondentRules: FilterRule[] = this.filterRules.filter(fr => fr.rule_type == FILTER_CORRESPONDENT)
-    return this.correspondents ?.filter(c => correspondentRules.find(cr => +cr.value == c.id))
+    return this.correspondents?.filter(c => correspondentRules.find(cr => +cr.value == c.id))
   }
 
   get selectedDocumentTypes(): PaperlessDocumentType[] {
     let documentTypeRules: FilterRule[] = this.filterRules.filter(fr => fr.rule_type == FILTER_DOCUMENT_TYPE)
-    return this.documentTypes ?.filter(dt => documentTypeRules.find(dtr => +dtr.value == dt.id))
+    return this.documentTypes?.filter(dt => documentTypeRules.find(dtr => +dtr.value == dt.id))
   }
 
   get titleFilter() {
     let existingRule = this.filterRules.find(rule => rule.rule_type == FILTER_TITLE)
-    return existingRule ? existingRule.value : ''
+    return existingRule? existingRule.value : ''
   }
 
   set titleFilter(value) {
@@ -121,7 +121,7 @@ export class FilterEditorComponent implements OnInit, OnDestroy {
 
     let filterRuleType = FILTER_RULE_TYPES.find(t => t.id == filterRuleTypeID)
 
-    let existingRule = this.filterRules.find(rule => rule.rule_type == filterRuleTypeID && rule.value == value ?.toString())
+    let existingRule = this.filterRules.find(rule => rule.rule_type == filterRuleTypeID && rule.value == value?.toString())
     let existingRuleOfSameType = this.filterRules.find(rule => rule.rule_type == filterRuleTypeID)
 
     if (existingRule) {
@@ -129,10 +129,10 @@ export class FilterEditorComponent implements OnInit, OnDestroy {
       this.filterRules.splice(this.filterRules.indexOf(existingRule), 1)
     } else if (filterRuleType.multi || !existingRuleOfSameType) {
       // if we allow multiple rules per type, or no rule of this type already exists, push a new rule.
-      this.filterRules.push({ rule_type: filterRuleTypeID, value: value ?.toString()})
+      this.filterRules.push({ rule_type: filterRuleTypeID, value: value?.toString()})
     } else {
       // otherwise (i.e., no multi support AND there's already a rule of this type), update the rule.
-      existingRuleOfSameType.value = value ?.toString()
+      existingRuleOfSameType.value = value?.toString()
     }
     this.applyFilters()
   }
@@ -165,22 +165,22 @@ export class FilterEditorComponent implements OnInit, OnDestroy {
   // Date handling
   get dateCreatedBefore(): NgbDateStruct {
     let createdBeforeRule: FilterRule = this.filterRules.find(fr => fr.rule_type == FILTER_CREATED_BEFORE)
-    return createdBeforeRule ? this.dateParser.parse(createdBeforeRule.value) : null
+    return createdBeforeRule? this.dateParser.parse(createdBeforeRule.value) : null
   }
 
   get dateCreatedAfter(): NgbDateStruct {
     let createdAfterRule: FilterRule = this.filterRules.find(fr => fr.rule_type == FILTER_CREATED_AFTER)
-    return createdAfterRule ? this.dateParser.parse(createdAfterRule.value) : null
+    return createdAfterRule? this.dateParser.parse(createdAfterRule.value) : null
   }
 
   get dateAddedBefore(): NgbDateStruct {
     let addedBeforeRule: FilterRule = this.filterRules.find(fr => fr.rule_type == FILTER_ADDED_BEFORE)
-    return addedBeforeRule ? this.dateParser.parse(addedBeforeRule.value) : null
+    return addedBeforeRule? this.dateParser.parse(addedBeforeRule.value) : null
   }
 
   get dateAddedAfter(): NgbDateStruct {
     let addedAfterRule: FilterRule = this.filterRules.find(fr => fr.rule_type == FILTER_ADDED_AFTER)
-    return addedAfterRule ? this.dateParser.parse(addedAfterRule.value) : null
+    return addedAfterRule? this.dateParser.parse(addedAfterRule.value) : null
   }
 
   onDatesCreatedSet(dates: DateSelection) {

--- a/src-ui/src/app/components/filter-editor/filter-editor.component.ts
+++ b/src-ui/src/app/components/filter-editor/filter-editor.component.ts
@@ -22,16 +22,16 @@ export class FilterEditorComponent implements OnInit, OnDestroy {
   generateFilterName() {
     if (this.filterRules.length == 1) {
       let rule = this.filterRules[0]
-      switch(this.filterRules[0].rule_type) {
-        
+      switch (this.filterRules[0].rule_type) {
+
         case FILTER_CORRESPONDENT:
-          return `Correspondent: ${this.correspondents.find(c => c.id == +rule.value)?.name}`
+          return `Correspondent: ${this.correspondents.find(c => c.id == +rule.value) ?.name}`
 
         case FILTER_DOCUMENT_TYPE:
-          return `Type: ${this.documentTypes.find(dt => dt.id == +rule.value)?.name}`
+          return `Type: ${this.documentTypes.find(dt => dt.id == +rule.value) ?.name}`
 
         case FILTER_HAS_TAG:
-          return `Tag: ${this.tags.find(t => t.id == +rule.value)?.name}`
+          return `Tag: ${this.tags.find(t => t.id == +rule.value) ?.name}`
 
       }
     }
@@ -55,24 +55,24 @@ export class FilterEditorComponent implements OnInit, OnDestroy {
 
   @Output()
   filterRulesChange = new EventEmitter<FilterRule[]>()
-  
+
   hasFilters() {
     return this.filterRules.length > 0
   }
 
   get selectedTags(): PaperlessTag[] {
     let tagRules: FilterRule[] = this.filterRules.filter(fr => fr.rule_type == FILTER_HAS_TAG)
-    return this.tags?.filter(t => tagRules.find(tr => +tr.value == t.id))
+    return this.tags ?.filter(t => tagRules.find(tr => +tr.value == t.id))
   }
 
   get selectedCorrespondents(): PaperlessCorrespondent[] {
     let correspondentRules: FilterRule[] = this.filterRules.filter(fr => fr.rule_type == FILTER_CORRESPONDENT)
-    return this.correspondents?.filter(c => correspondentRules.find(cr => +cr.value == c.id))
+    return this.correspondents ?.filter(c => correspondentRules.find(cr => +cr.value == c.id))
   }
 
   get selectedDocumentTypes(): PaperlessDocumentType[] {
     let documentTypeRules: FilterRule[] = this.filterRules.filter(fr => fr.rule_type == FILTER_DOCUMENT_TYPE)
-    return this.documentTypes?.filter(dt => documentTypeRules.find(dtr => +dtr.value == dt.id))
+    return this.documentTypes ?.filter(dt => documentTypeRules.find(dtr => +dtr.value == dt.id))
   }
 
   get titleFilter() {
@@ -121,18 +121,18 @@ export class FilterEditorComponent implements OnInit, OnDestroy {
 
     let filterRuleType = FILTER_RULE_TYPES.find(t => t.id == filterRuleTypeID)
 
-    let existingRule = this.filterRules.find(rule => rule.rule_type == filterRuleTypeID && rule.value == value?.toString())
+    let existingRule = this.filterRules.find(rule => rule.rule_type == filterRuleTypeID && rule.value == value ?.toString())
     let existingRuleOfSameType = this.filterRules.find(rule => rule.rule_type == filterRuleTypeID)
-    
+
     if (existingRule) {
       // if this exact rule already exists, remove it in all cases.
       this.filterRules.splice(this.filterRules.indexOf(existingRule), 1)
     } else if (filterRuleType.multi || !existingRuleOfSameType) {
       // if we allow multiple rules per type, or no rule of this type already exists, push a new rule.
-      this.filterRules.push({rule_type: filterRuleTypeID, value: value?.toString()})
+      this.filterRules.push({ rule_type: filterRuleTypeID, value: value ?.toString()})
     } else {
       // otherwise (i.e., no multi support AND there's already a rule of this type), update the rule.
-      existingRuleOfSameType.value = value?.toString()
+      existingRuleOfSameType.value = value ?.toString()
     }
     this.applyFilters()
   }
@@ -141,7 +141,7 @@ export class FilterEditorComponent implements OnInit, OnDestroy {
     let existingRule = this.filterRules.find(rule => rule.rule_type == FILTER_TITLE)
 
     if (!existingRule && title) {
-      this.filterRules.push({rule_type: FILTER_TITLE, value: title})
+      this.filterRules.push({ rule_type: FILTER_TITLE, value: title })
     } else if (existingRule && !title) {
       this.filterRules.splice(this.filterRules.findIndex(rule => rule.rule_type == FILTER_TITLE), 1)
     } else if (existingRule && title) {
@@ -162,23 +162,7 @@ export class FilterEditorComponent implements OnInit, OnDestroy {
     this.toggleFilterRule(FILTER_DOCUMENT_TYPE, documentTypeId)
   }
 
-
-
   // Date handling
-
-
-  onDatesCreatedSet(dates: DateSelection) {
-    this.setDateCreatedBefore(dates.before)
-    this.setDateCreatedAfter(dates.after)
-    this.applyFilters()
-  }
-
-  onDatesAddedSet(dates: DateSelection) {
-    this.setDateAddedBefore(dates.before)
-    this.setDateAddedAfter(dates.after)
-    this.applyFilters()
-  }
-
   get dateCreatedBefore(): NgbDateStruct {
     let createdBeforeRule: FilterRule = this.filterRules.find(fr => fr.rule_type == FILTER_CREATED_BEFORE)
     return createdBeforeRule ? this.dateParser.parse(createdBeforeRule.value) : null
@@ -199,24 +183,32 @@ export class FilterEditorComponent implements OnInit, OnDestroy {
     return addedAfterRule ? this.dateParser.parse(addedAfterRule.value) : null
   }
 
-  setDateCreatedBefore(date?: NgbDateStruct) {
-    if (date) this.setDateFilter(date, FILTER_CREATED_BEFORE)
-    else this.clearDateFilter(FILTER_CREATED_BEFORE)
+  onDatesCreatedSet(dates: DateSelection) {
+    if (dates.hasOwnProperty('before')) {
+      if (dates.before !== null) this.setDateFilter(dates.before, FILTER_CREATED_BEFORE)
+      else this.clearDateFilter(FILTER_CREATED_BEFORE)
+    }
+
+    if (dates.hasOwnProperty('after')) {
+      if (dates.after !== null) this.setDateFilter(dates.after, FILTER_CREATED_AFTER)
+      else this.clearDateFilter(FILTER_CREATED_AFTER)
+    }
+
+    this.applyFilters()
   }
 
-  setDateCreatedAfter(date?: NgbDateStruct) {
-    if (date) this.setDateFilter(date, FILTER_CREATED_AFTER)
-    else this.clearDateFilter(FILTER_CREATED_AFTER)
-  }
+  onDatesAddedSet(dates: DateSelection) {
+    if (dates.hasOwnProperty('before')) {
+      if (dates.before !== null) this.setDateFilter(dates.before, FILTER_ADDED_BEFORE)
+      else this.clearDateFilter(FILTER_ADDED_BEFORE)
+    }
 
-  setDateAddedBefore(date?: NgbDateStruct) {
-    if (date) this.setDateFilter(date, FILTER_ADDED_BEFORE)
-    else this.clearDateFilter(FILTER_ADDED_BEFORE)
-  }
+    if (dates.hasOwnProperty('after')) {
+      if (dates.after !== null) this.setDateFilter(dates.after, FILTER_ADDED_AFTER)
+      else this.clearDateFilter(FILTER_ADDED_AFTER)
+    }
 
-  setDateAddedAfter(date?: NgbDateStruct) {
-    if (date) this.setDateFilter(date, FILTER_ADDED_AFTER)
-    else this.clearDateFilter(FILTER_ADDED_AFTER)
+    this.applyFilters()
   }
 
   setDateFilter(date: NgbDateStruct, dateRuleTypeID: number) {
@@ -226,7 +218,7 @@ export class FilterEditorComponent implements OnInit, OnDestroy {
     if (existingRule) {
       existingRule.value = newValue
     } else {
-      this.filterRules.push({rule_type: dateRuleTypeID, value: newValue})
+      this.filterRules.push({ rule_type: dateRuleTypeID, value: newValue })
     }
   }
 


### PR DESCRIPTION
This PR closes #144 , it adds:

- Clear buttons for each date field (after / before)
- Allows date field searching using keyboard input
- Shows visual feedback if date entered with keyboard is invalid
- Executes search after 'Enter' key pressed
- Swaps position of after & before (because I realized if you think of a range like _From X to Y_ then "after" (X) comes first.