### PR TITLE
Automatic CI/CD multiarch docker builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,14 +60,17 @@ jobs:
       after_success:
         - true
       script:
-        - echo "Starting arm64v8 build, login to docker"
         - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+        # register binfmt stuff for qemu-static binaries so we can use userland-emulation
+        - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+        # replace the multi-arch reference with a specific, arm32v7 version. else docker will use the platform specific one,
+        # which is amd64.
+        - sed -i 's/FROM node:15/FROM node@sha256:5a14c8bf5020253f322b8f1f6bec4c34cafb0097acf1c1155506ee17b3c71119/g' Dockerfile
+        - sed -i 's/FROM python:3.7-slim/FROM python@sha256:d75eb820f62221ce8e40c5d8dbe988aa417e88553ef095a4a7591d7318da8486/g' Dockerfile
         # travis_wait 60 tells travis to wait for up to 60 minutes - default is 20, which is too short
-        - echo "Build ..."
         - travis_wait 60 docker build -f Dockerfile --tag=${DOCKER_REPO}:${TRAVIS_COMMIT}-arm64v8 .
-        - echo "Push"
         - docker push ${DOCKER_REPO}:${TRAVIS_COMMIT}-arm64v8
-      arch: arm64
+      arch: amd64
       on:
         condition: '"${BUILD_DOCKER}" = 1'
     

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,9 +60,12 @@ jobs:
       after_success:
         - true
       script:
+        - echo "Starting arm64v8 build, login to docker"
         - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         # travis_wait 60 tells travis to wait for up to 60 minutes - default is 20, which is too short
+        - echo "Build ..."
         - travis_wait 60 docker build -f Dockerfile --tag=${DOCKER_REPO}:${TRAVIS_COMMIT}-arm64v8 .
+        - echo "Push"
         - docker push ${DOCKER_REPO}:${TRAVIS_COMMIT}-arm64v8
       arch: arm64
       on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ jobs:
       after_success:
         - true
       script:
-        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin"
+        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         # travis_wait 60 tells travis to wait for up to 60 minutes - default is 20, which is too short
         - travis_wait 60 docker build -f Dockerfile --tag=${DOCKER_REPO}:${TRAVIS_COMMIT}-arm64v8 .
         - docker push ${DOCKER_REPO}:${TRAVIS_COMMIT}-arm64v8

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,33 +5,33 @@ os: linux
 
 jobs:
   include:
-    - name: "Paperless on Python 3.6"
-      python: "3.6"
-
-    - name: "Paperless on Python 3.7"
-      python: "3.7"
-
-    - name: "Paperless on Python 3.8"
-      python: "3.8"
-
-    - name: "Documentation"
-      script:
-        - cd docs/
-        - make html
-      after_success: true
-
-    - name: "Front end"
-      language: node_js
-      node_js:
-        - 15
-      before_install: true
-      install:
-        - cd src-ui/
-        - npm install -g @angular/cli
-        - npm install
-      script:
-        - ng build --prod
-      after_success: true
+#    - name: "Paperless on Python 3.6"
+#      python: "3.6"
+#
+#    - name: "Paperless on Python 3.7"
+#      python: "3.7"
+#
+#    - name: "Paperless on Python 3.8"
+#      python: "3.8"
+#
+#    - name: "Documentation"
+#      script:
+#        - cd docs/
+#        - make html
+#      after_success: true
+#
+#    - name: "Front end"
+#      language: node_js
+#      node_js:
+#        - 15
+#      before_install: true
+#      install:
+#        - cd src-ui/
+#        - npm install -g @angular/cli
+#        - npm install
+#      script:
+#        - ng build --prod
+#      after_success: true
 
     - stage: build_docker
       name: amd64 docker build

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,6 +91,8 @@ jobs:
         # travis_wait 60 tells travis to wait for up to 60 minutes - default is 20, which is too short
         - travis_wait 60 docker build -f Dockerfile --tag=${DOCKER_REPO}:${TRAVIS_COMMIT}-arm32v7 .
         - docker push ${DOCKER_REPO}:${TRAVIS_COMMIT}-arm32v7
+      env:
+        - DOCKER_CLI_EXPERIMENTAL=enabled # required for manifest support
       on:
         condition: '"${BUILD_DOCKER}" = 1'
     

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,12 +60,13 @@ jobs:
       after_success:
         - true
       script:
+        - uname -a
         - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         # travis_wait 60 tells travis to wait for up to 60 minutes - default is 20, which is too short
         - travis_wait 60 docker build -f Dockerfile --tag=${DOCKER_REPO}:${TRAVIS_COMMIT}-arm64v8 .
         - docker push ${DOCKER_REPO}:${TRAVIS_COMMIT}-arm64v8
       arch: arm64-graviton2
-      virt: vm      
+      virt: lxc
       on:
         condition: '"${BUILD_DOCKER}" = 1'
     
@@ -85,8 +86,8 @@ jobs:
         - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
         # replace the multi-arch reference with a specific, arm32v7 version. else docker will use the platform specific one,
         # which is amd64.
-        - sed -i 's/FROM node:15/FROM node@sha256:e9bf2028bd59399afd3f6665f427a07b7ddfee07cffdf2061c39d991a3b3e332/g' Dockerfile
-        - sed -i 's/FROM python:3.7-slim/FROM python@sha256:843dd86fa35b923095b5db60c6e2e296013d647c8327aeba0e7638e7f0a43373/g' Dockerfile
+        - sed -i "s/FROM node:15/FROM node@$(docker manifest inspect node:15 | jq -r '.manifests [] | select (.platform.variant == "v7") | .digest')/g" Dockerfile
+        - sed -i "s/FROM python:3.7-slim/FROM python@$(docker manifest inspect python:3.7-slim | jq -r '.manifests [] | select (.platform.variant == "v7") | .digest')/g" Dockerfile
         # travis_wait 60 tells travis to wait for up to 60 minutes - default is 20, which is too short
         - travis_wait 60 docker build -f Dockerfile --tag=${DOCKER_REPO}:${TRAVIS_COMMIT}-arm32v7 .
         - docker push ${DOCKER_REPO}:${TRAVIS_COMMIT}-arm32v7

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,7 @@ jobs:
         - docker push ${DOCKER_REPO}:${TRAVIS_COMMIT}-arm64v8
       arch: arm64-graviton2
       virt: vm
+      group: edge
       on:
         condition: '"${BUILD_DOCKER}" = 1'
     

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ jobs:
         - travis_wait 60 docker build -f Dockerfile --tag=${DOCKER_REPO}:${TRAVIS_COMMIT}-arm64v8 .
         - docker push ${DOCKER_REPO}:${TRAVIS_COMMIT}-arm64v8
       arch: arm64-graviton2
-      virt: lxc
+      virt: vm
       on:
         condition: '"${BUILD_DOCKER}" = 1'
     

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,17 +60,12 @@ jobs:
       after_success:
         - true
       script:
-        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-        # register binfmt stuff for qemu-static binaries so we can use userland-emulation
-        - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-        # replace the multi-arch reference with a specific, arm32v7 version. else docker will use the platform specific one,
-        # which is amd64.
-        - sed -i 's/FROM node:15/FROM node@sha256:5a14c8bf5020253f322b8f1f6bec4c34cafb0097acf1c1155506ee17b3c71119/g' Dockerfile
-        - sed -i 's/FROM python:3.7-slim/FROM python@sha256:d75eb820f62221ce8e40c5d8dbe988aa417e88553ef095a4a7591d7318da8486/g' Dockerfile
+        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin"
         # travis_wait 60 tells travis to wait for up to 60 minutes - default is 20, which is too short
         - travis_wait 60 docker build -f Dockerfile --tag=${DOCKER_REPO}:${TRAVIS_COMMIT}-arm64v8 .
         - docker push ${DOCKER_REPO}:${TRAVIS_COMMIT}-arm64v8
-      arch: amd64
+      arch: arm64-graviton2
+      virt: vm      
       on:
         condition: '"${BUILD_DOCKER}" = 1'
     

--- a/.travis.yml
+++ b/.travis.yml
@@ -110,7 +110,7 @@ jobs:
         - true
       script:
         - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-        - docker manifest create ${DOCKER_REPO}:${TRAVIS_COMMIT} ${DOCKER_REPO}:${TRAVIS_COMMIT}-amd64 ${DOCKER_REPO}:${TRAVIS_COMMIT}-arm64v8 ${DOCKER_REPO}:${TRAVIS_COMMIT}-arm32v7 ${DOCKER_REPO}:${TRAVIS_COMMIT}-arm32v6
+        - docker manifest create ${DOCKER_REPO}:${TRAVIS_COMMIT} ${DOCKER_REPO}:${TRAVIS_COMMIT}-amd64 ${DOCKER_REPO}:${TRAVIS_COMMIT}-arm64v8 ${DOCKER_REPO}:${TRAVIS_COMMIT}-arm32v7
         - docker manifest annotate ${DOCKER_REPO}:${TRAVIS_COMMIT} ${DOCKER_REPO}:${TRAVIS_COMMIT}-arm32v7 --os linux --arch arm --variant v7
         - docker manifest annotate ${DOCKER_REPO}:${TRAVIS_COMMIT} ${DOCKER_REPO}:${TRAVIS_COMMIT}-arm64v8 --os linux --arch arm64 --variant v8
         - docker manifest push --purge ${DOCKER_REPO}:${TRAVIS_COMMIT}
@@ -124,7 +124,7 @@ jobs:
         - |
           if [ "${DOCKER_TAG}" != "" ]; then
             echo "Create Tag ${DOCKER_TAG}"
-            docker manifest create ${DOCKER_REPO}:${DOCKER_TAG} ${DOCKER_REPO}:${TRAVIS_COMMIT}-amd64 ${DOCKER_REPO}:${TRAVIS_COMMIT}-arm64v8 ${DOCKER_REPO}:${TRAVIS_COMMIT}-arm32v7 ${DOCKER_REPO}:${TRAVIS_COMMIT}-arm32v6
+            docker manifest create ${DOCKER_REPO}:${DOCKER_TAG} ${DOCKER_REPO}:${TRAVIS_COMMIT}-amd64 ${DOCKER_REPO}:${TRAVIS_COMMIT}-arm64v8 ${DOCKER_REPO}:${TRAVIS_COMMIT}-arm32v7
             docker manifest annotate ${DOCKER_REPO}:${DOCKER_TAG} ${DOCKER_REPO}:${TRAVIS_COMMIT}-arm32v7 --os linux --arch arm --variant v7
             docker manifest annotate ${DOCKER_REPO}:${DOCKER_TAG} ${DOCKER_REPO}:${TRAVIS_COMMIT}-arm64v8 --os linux --arch arm64 --variant v8
             docker manifest push --purge ${DOCKER_REPO}:${DOCKER_TAG}

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,33 +5,33 @@ os: linux
 
 jobs:
   include:
-#    - name: "Paperless on Python 3.6"
-#      python: "3.6"
-#
-#    - name: "Paperless on Python 3.7"
-#      python: "3.7"
-#
-#    - name: "Paperless on Python 3.8"
-#      python: "3.8"
-#
-#    - name: "Documentation"
-#      script:
-#        - cd docs/
-#        - make html
-#      after_success: true
-#
-#    - name: "Front end"
-#      language: node_js
-#      node_js:
-#        - 15
-#      before_install: true
-#      install:
-#        - cd src-ui/
-#        - npm install -g @angular/cli
-#        - npm install
-#      script:
-#        - ng build --prod
-#      after_success: true
+    - name: "Paperless on Python 3.6"
+      python: "3.6"
+
+    - name: "Paperless on Python 3.7"
+      python: "3.7"
+
+    - name: "Paperless on Python 3.8"
+      python: "3.8"
+
+    - name: "Documentation"
+      script:
+        - cd docs/
+        - make html
+      after_success: true
+
+    - name: "Front end"
+      language: node_js
+      node_js:
+        - 15
+      before_install: true
+      install:
+        - cd src-ui/
+        - npm install -g @angular/cli
+        - npm install
+      script:
+        - ng build --prod
+      after_success: true
 
     - stage: build_docker
       name: amd64 docker build
@@ -60,7 +60,6 @@ jobs:
       after_success:
         - true
       script:
-        - uname -a
         - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         # travis_wait 60 tells travis to wait for up to 60 minutes - default is 20, which is too short
         - travis_wait 60 docker build -f Dockerfile --tag=${DOCKER_REPO}:${TRAVIS_COMMIT}-arm64v8 .

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,102 @@ jobs:
         - ng build --prod
       after_success: true
 
+    - stage: build_docker
+      name: amd64 docker build
+      services:
+        - docker
+      before_install:
+        - true
+      install:
+        - true
+      after_success:
+        - true
+      script:
+        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+        - docker build -f Dockerfile --tag=${DOCKER_REPO}:${TRAVIS_COMMIT}-amd64 .
+        - docker push ${DOCKER_REPO}:${TRAVIS_COMMIT}-amd64
+      on:
+        condition: '"${BUILD_DOCKER}" = 1'
+    - stage: build_docker
+      name: arm64v8 docker build
+      services:
+        - docker
+      before_install:
+        - true
+      install:
+        - true
+      after_success:
+        - true
+      script:
+        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+        # travis_wait 60 tells travis to wait for up to 60 minutes - default is 20, which is too short
+        - travis_wait 60 docker build -f Dockerfile --tag=${DOCKER_REPO}:${TRAVIS_COMMIT}-arm64v8 .
+        - docker push ${DOCKER_REPO}:${TRAVIS_COMMIT}-arm64v8
+      arch: arm64
+      on:
+        condition: '"${BUILD_DOCKER}" = 1'
+    
+    - stage: build_docker
+      name: arm32v7 docker build
+      services:
+        - docker
+      before_install:
+        - true
+      install:
+        - true
+      after_success:
+        - true
+      script:
+        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+        # register binfmt stuff for qemu-static binaries so we can use userland-emulation
+        - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+        # replace the multi-arch reference with a specific, arm32v7 version. else docker will use the platform specific one,
+        # which is amd64.
+        - sed -i 's/FROM node:15/FROM node@sha256:e9bf2028bd59399afd3f6665f427a07b7ddfee07cffdf2061c39d991a3b3e332/g' Dockerfile
+        - sed -i 's/FROM python:3.7-slim/FROM python@sha256:843dd86fa35b923095b5db60c6e2e296013d647c8327aeba0e7638e7f0a43373/g' Dockerfile
+        # travis_wait 60 tells travis to wait for up to 60 minutes - default is 20, which is too short
+        - travis_wait 60 docker build -f Dockerfile --tag=${DOCKER_REPO}:${TRAVIS_COMMIT}-arm32v7 .
+        - docker push ${DOCKER_REPO}:${TRAVIS_COMMIT}-arm32v7
+      on:
+        condition: '"${BUILD_DOCKER}" = 1'
+    
+    - stage: publish_manifest
+      env:
+        - DOCKER_CLI_EXPERIMENTAL=enabled # required for manifest support
+      services:
+        - docker
+      before_install:
+        - true
+      install:
+        - true
+      after_success:
+        - true
+      script:
+        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+        - docker manifest create ${DOCKER_REPO}:${TRAVIS_COMMIT} ${DOCKER_REPO}:${TRAVIS_COMMIT}-amd64 ${DOCKER_REPO}:${TRAVIS_COMMIT}-arm64v8 ${DOCKER_REPO}:${TRAVIS_COMMIT}-arm32v7 ${DOCKER_REPO}:${TRAVIS_COMMIT}-arm32v6
+        - docker manifest annotate ${DOCKER_REPO}:${TRAVIS_COMMIT} ${DOCKER_REPO}:${TRAVIS_COMMIT}-arm32v7 --os linux --arch arm --variant v7
+        - docker manifest annotate ${DOCKER_REPO}:${TRAVIS_COMMIT} ${DOCKER_REPO}:${TRAVIS_COMMIT}-arm64v8 --os linux --arch arm64 --variant v8
+        - docker manifest push --purge ${DOCKER_REPO}:${TRAVIS_COMMIT}
+        - |
+          if [ "${TRAVIS_BRANCH}" = "master" ]; then
+            echo "Master branch detected"
+            DOCKER_TAG="latest"
+          else
+            DOCKER_TAG=${TRAVIS_TAG}
+          fi
+        - |
+          if [ "${DOCKER_TAG}" != "" ]; then
+            echo "Create Tag ${DOCKER_TAG}"
+            docker manifest create ${DOCKER_REPO}:${DOCKER_TAG} ${DOCKER_REPO}:${TRAVIS_COMMIT}-amd64 ${DOCKER_REPO}:${TRAVIS_COMMIT}-arm64v8 ${DOCKER_REPO}:${TRAVIS_COMMIT}-arm32v7 ${DOCKER_REPO}:${TRAVIS_COMMIT}-arm32v6
+            docker manifest annotate ${DOCKER_REPO}:${DOCKER_TAG} ${DOCKER_REPO}:${TRAVIS_COMMIT}-arm32v7 --os linux --arch arm --variant v7
+            docker manifest annotate ${DOCKER_REPO}:${DOCKER_TAG} ${DOCKER_REPO}:${TRAVIS_COMMIT}-arm64v8 --os linux --arch arm64 --variant v8
+            docker manifest push --purge ${DOCKER_REPO}:${DOCKER_TAG}
+          else
+            echo "Not a tag and not on master, so not pushing tag/master specific manifest"
+          fi
+      on:
+        condition: '"${BUILD_DOCKER}" = 1'
+
 
 before_install:
   - sudo apt-get update -qq

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update \
 		libpq-dev \
 		libqpdf-dev \
 		libxml2 \
+		libxslt-dev \
 		optipng \
 		pngquant \
 		qpdf \


### PR DESCRIPTION
As discussed in https://github.com/jonaswinkler/paperless-ng/issues/151 I've been porting my old pull request from the-paperless-project over to this one.

It extends the travis-ci pipeline with three docker builds, one for each x86_64, aarch64 (arm64) and arm32v7 and then creates a multi-arch docker manifest, so it can be used seamlessly on all three platforms.

It makes use of travis-ci's new arm64-graviton2 build machine, so travis-ci.com (not .org) needs to be used. I was able to migrate my account within minutes, so I hope this is not a problem.

The following environment variables and secrets need to be defined in travis:
DOCKER_REPO (f.e. jonaswinkler/paperless-ng)
DOCKER_USERNAME (f.e. jonaswinkler)
DOCKER_PASSWORD (should not be your regular password, but rather a deployment key generated on dockerhub)

Tagging is scripted like so:
- builds from the master branch end up as "latest" images
- builds from a git tag end up with that version as tag, f.e. tag "v1.0-rc1" will end up in jonaswinkler/paperless-ng:v1.0-rc1.
- all builds are always tagged with the git commit hash, so it's easy to test a non-released version

For the qemu build, which is currently only the arm32v7 one, jq is used to parse the docker manifest to get the latest version.  This is necessary for qemu to pull the correct base-image. That can be improved a bit .. if the base image changes, that always needs to be adapted in the build script. Not sure if it's worth the efford, so I've left it with this rather simple version.

You can find travis-ci runs on my branch here: https://travis-ci.com/github/MarkSchmitt/paperless

And results here https://hub.docker.com/r/moztr/paperless-travis/tags

As @obbardc pointed out in https://github.com/jonaswinkler/paperless-ng/issues/151#issuecomment-749700804 that github actions can do the same, but at this point, as there're no aarch64 wheels precompiled, I don't think qemu can be quick enough to handle it (in the tests with travis it was not, with a timeout of 60 minutes for the build). The native arm64 graviton2 machines travis uses from AWS seem to be very fast, so they can handle the amount of compiling necessary to build the wheels from scratch. However, later, when aarch64 wheels are available, I think using github actions might be a good alternative. So I suggest doing it the travis-way first, and then migrate later to a cleaner solution. To get something off the ground, and improve on it later.