### PR TITLE
Add docs for non-docker-compose user creation

### DIFF
--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -190,6 +190,12 @@ Docker Route
     .. code-block:: shell-session
 
         $ docker-compose run --rm webserver createsuperuser
+				
+    Alternatively, if you are not using docker-compose, execute the following command inside the container:
+		
+    .. code-block:: shell-session
+		
+        $ python3 /usr/src/paperless/src/manage.py createsuperuser
 
     This will prompt you to set a username, an optional e-mail address and
     finally a password.


### PR DESCRIPTION
I was setting up paperless-ng on docker without using docker-compose. I ran into the issue that there was no documentation on how to do it on docker without compose. This PR will add the missing doc. 