### PR TITLE
Avoid ios safari input zoom

### DIFF
--- a/src-ui/src/styles.scss
+++ b/src-ui/src/styles.scss
@@ -100,3 +100,13 @@ body {
     padding-top: 1px;
   }
 }
+
+@supports (-webkit-touch-callout: none) {
+  input[type="number"],
+  input[type="search"],
+  input[type="text"],
+  select:focus,
+  textarea {
+    font-size: 16px;
+  }
+}


### PR DESCRIPTION
Again, hope Im not interrupting your "break" @jonaswinkler , obviously none of this stuff is urgent!

This PR fixes a small (but significant) annoyance on iOS Safari where `<input>` elements zoom the entire page when entered, for an app like Paperless-ng🎄 its pretty disruptive. This PR just selectively sets the font size to 16px on these elements _only on iOS Safari_ using CSS `@supports`. Small part of #24 

If youre curious theres more about this here: https://stackoverflow.com/questions/2989263/disable-auto-zoom-in-input-text-tag-safari-on-iphone . The alternative solution I have used in the past is to set `maximum-scale=1` to the `<meta name="viewport"` but that has [negative accessibility implications](http://a11yproject.com/posts/never-use-maximum-scale) and disables pinch-to-zoom on Android.

Cheers 🍻🎄