### PR TITLE
Travis multi-arch builds: only build and push docker containers on special branches and tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,12 @@ language: python
 dist: focal
 os: linux
 
+stages:
+ - name: build_docker
+   if: branch =~ /^(master|dev|ng-.*)$/
+ - name: publish_manifest
+   if: branch =~ /^(master|dev|ng-.*)$/
+
 jobs:
   include:
     - name: "Paperless on Python 3.6"
@@ -47,8 +53,6 @@ jobs:
         - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         - docker build -f Dockerfile --tag=${DOCKER_REPO}:${TRAVIS_COMMIT}-amd64 .
         - docker push ${DOCKER_REPO}:${TRAVIS_COMMIT}-amd64
-      on:
-        condition: '"${BUILD_DOCKER}" = 1 and ( branch =~ /^(master|dev|ng-.*)$/)'
     - stage: build_docker
       name: arm64v8 docker build
       services:
@@ -67,8 +71,6 @@ jobs:
       arch: arm64-graviton2
       virt: vm
       group: edge
-      on:
-        condition: '"${BUILD_DOCKER}" = 1 and ( branch =~ /^(master|dev|ng-.*)$/)'
     - stage: build_docker
       name: arm32v7 docker build
       services:
@@ -92,8 +94,6 @@ jobs:
         - docker push ${DOCKER_REPO}:${TRAVIS_COMMIT}-arm32v7
       env:
         - DOCKER_CLI_EXPERIMENTAL=enabled # required for manifest support
-      on:
-        condition: '"${BUILD_DOCKER}" = 1 and ( branch =~ /^(master|dev|ng-.*)$/)'
     - stage: publish_manifest
       env:
         - DOCKER_CLI_EXPERIMENTAL=enabled # required for manifest support
@@ -128,8 +128,6 @@ jobs:
           else
             echo "Not a tag and not on master, so not pushing tag/master specific manifest"
           fi
-      on:
-        condition: '"${BUILD_DOCKER}" = 1 and ( branch =~ /^(master|dev|ng-.*)$/)'
 
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ dist: focal
 os: linux
 
 stages:
+ - name: test
  - name: build_docker
    if: branch =~ /^(master|dev|ng-.*)$/
  - name: publish_manifest
@@ -12,21 +13,26 @@ stages:
 jobs:
   include:
     - name: "Paperless on Python 3.6"
+      stage: test
       python: "3.6"
 
     - name: "Paperless on Python 3.7"
+      stage: test
       python: "3.7"
 
     - name: "Paperless on Python 3.8"
+      stage: test
       python: "3.8"
 
     - name: "Documentation"
+      stage: test
       script:
         - cd docs/
         - make html
       after_success: true
 
     - name: "Front end"
+      stage: test
       language: node_js
       node_js:
         - 15

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ jobs:
         - docker build -f Dockerfile --tag=${DOCKER_REPO}:${TRAVIS_COMMIT}-amd64 .
         - docker push ${DOCKER_REPO}:${TRAVIS_COMMIT}-amd64
       on:
-        condition: '"${BUILD_DOCKER}" = 1'
+        condition: '"${BUILD_DOCKER}" = 1 and ( branch =~ /^(master|dev|ng-.*)$/)'
     - stage: build_docker
       name: arm64v8 docker build
       services:
@@ -68,8 +68,7 @@ jobs:
       virt: vm
       group: edge
       on:
-        condition: '"${BUILD_DOCKER}" = 1'
-    
+        condition: '"${BUILD_DOCKER}" = 1 and ( branch =~ /^(master|dev|ng-.*)$/)'
     - stage: build_docker
       name: arm32v7 docker build
       services:
@@ -94,8 +93,7 @@ jobs:
       env:
         - DOCKER_CLI_EXPERIMENTAL=enabled # required for manifest support
       on:
-        condition: '"${BUILD_DOCKER}" = 1'
-    
+        condition: '"${BUILD_DOCKER}" = 1 and ( branch =~ /^(master|dev|ng-.*)$/)'
     - stage: publish_manifest
       env:
         - DOCKER_CLI_EXPERIMENTAL=enabled # required for manifest support
@@ -131,7 +129,7 @@ jobs:
             echo "Not a tag and not on master, so not pushing tag/master specific manifest"
           fi
       on:
-        condition: '"${BUILD_DOCKER}" = 1'
+        condition: '"${BUILD_DOCKER}" = 1 and ( branch =~ /^(master|dev|ng-.*)$/)'
 
 
 before_install:


### PR DESCRIPTION
This pull request solves the question from this comment: https://github.com/jonaswinkler/paperless-ng/pull/178#issuecomment-750305475
> Let's also say I only want to build images for the branches `master`, `dev` and all tags that match `ng-*`, how would I do that? I don't necessarily need images for every commit, building and tagging `dev` is usually enough for testing before releases.

With this change, stages get defined and the docker specific stages are only executed if the branch or tag (for travis it's all the same) match this regex: `/^(master|dev|ng-.*)$/`

Hope we can get this in, also in the master, so I can start using the official images on my multi-arch k3s/k8s cluster :)