### PR TITLE
Allow extending INSTALLED_APPS via environment

### DIFF
--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -69,7 +69,7 @@ SCRATCH_DIR = os.getenv("PAPERLESS_SCRATCH_DIR", "/tmp/paperless")
 # Application Definition                                                      #
 ###############################################################################
 
-env_apps = os.getenv("PAPERLESS_APPS") if os.getenv("PAPERLESS_APPS") else []
+env_apps = os.getenv("PAPERLESS_APPS").split(",") if os.getenv("PAPERLESS_APPS") else []
 
 INSTALLED_APPS = [
     "whitenoise.runserver_nostatic",

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -69,6 +69,8 @@ SCRATCH_DIR = os.getenv("PAPERLESS_SCRATCH_DIR", "/tmp/paperless")
 # Application Definition                                                      #
 ###############################################################################
 
+env_apps = os.getenv("PAPERLESS_APPS") if os.getenv("PAPERLESS_APPS") else []
+
 INSTALLED_APPS = [
     "whitenoise.runserver_nostatic",
 
@@ -95,7 +97,7 @@ INSTALLED_APPS = [
 
     "django_q",
 
-]
+] + env_apps
 
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': [


### PR DESCRIPTION
This allows a user to add "apps" (aka parsers) through the environment.

Especially useful when using Docker, and adding a test-parser.

Usage:

```yaml
services:
  webserver:
    environment:
      PAPERLESS_APPS: paperless_tika.apps.PaperlessTikaConfig
```

You can add more by separating them with a `,`:

```yaml
PAPERLESS_APPS: app1,app2
```