### PR TITLE
Fix more dark mode inconsistencies

### DIFF
--- a/src-ui/src/theme_dark.scss
+++ b/src-ui/src/theme_dark.scss
@@ -174,6 +174,17 @@ $border-color-dark-mode: #47494f;
     color: $text-color-dark-mode;
     border-color: $border-color-dark-mode;
 
+    .des,
+    .asc {
+      background-color: transparent !important;
+      color: $text-color-dark-mode;
+      border-color: $border-color-dark-mode;
+
+      &::after {
+        filter: invert(0.8); /* arrow is a black inline png bkgd image (!) so use filter */
+      }
+    }
+
     tr:hover {
       background-color: $bg-light-dark-mode;
       color: $text-color-dark-mode-accent;
@@ -250,13 +261,18 @@ $border-color-dark-mode: #47494f;
     background-color: $bg-dark-mode !important;
   }
 
-  .form-control,
+  .form-control:not(.is-invalid):not(.btn),
+  input:not(.is-invalid),
+  textarea:not(.is-invalid) {
+    border-color: $border-color-dark-mode; /* we dont want to override controls that get highlighting for errors */
+  }
+
+  .form-control:not(.btn),
   input,
   select,
   textarea {
     background-color: $bg-dark-mode;
     color: $text-color-dark-mode;
-    border-color: $border-color-dark-mode;
 
     &::placeholder {
       color: $text-color-dark-mode;
@@ -324,6 +340,12 @@ $border-color-dark-mode: #47494f;
 
   .progress {
     background-color: $border-color-dark-mode;
+  }
+
+  .alert-danger {
+    color: $text-color-dark-mode-accent;
+    background-color: darken($danger-dark-mode, 20%);
+    border-color: darken($danger-dark-mode, 20%);
   }
 }
 


### PR DESCRIPTION
This PR closes #276 as discussed therein, it addresses a few dark mode inconsistencies.

<img width="562" alt="Screen Shot 2021-01-04 at 7 32 34 PM" src="https://user-images.githubusercontent.com/4887959/103603643-f0c58d80-4ec3-11eb-9799-361071914e1d.png">
<img width="285" alt="Screen Shot 2021-01-04 at 7 32 42 PM" src="https://user-images.githubusercontent.com/4887959/103603645-f28f5100-4ec3-11eb-93a6-9e738453983b.png">
<img width="372" alt="Screen Shot 2021-01-04 at 7 33 03 PM" src="https://user-images.githubusercontent.com/4887959/103603648-f4591480-4ec3-11eb-8293-9cb04d5a1752.png">
<img width="724" alt="Screen Shot 2021-01-04 at 7 33 20 PM" src="https://user-images.githubusercontent.com/4887959/103603650-f58a4180-4ec3-11eb-979b-3c9a859ab591.png">
