### PR TITLE
Miscellaneous CSS fixes

### DIFF
--- a/src-ui/src/app/components/app-frame/app-frame.component.scss
+++ b/src-ui/src/app/components/app-frame/app-frame.component.scss
@@ -113,7 +113,7 @@
     background-color: rgba(0, 0, 0, 0.15);
     padding-left: 1.8rem;
     border-color: rgba(255, 255, 255, 0.2);
-    transition: flex 0.3s ease;
+    transition: all .3s ease, padding-left 0s ease, background-color 0s ease; // Safari requires all
     max-width: 600px;
     min-width: 300px; // 1/2 max
 

--- a/src-ui/src/app/components/dashboard/widgets/saved-view-widget/saved-view-widget.component.scss
+++ b/src-ui/src/app/components/dashboard/widgets/saved-view-widget/saved-view-widget.component.scss
@@ -1,7 +1,8 @@
 table {
   overflow-wrap: anywhere;
+  table-layout: fixed;
 }
 
 th:first-child {
-  min-width: 5rem;
+  width: 25%;
 }

--- a/src-ui/src/theme_dark.scss
+++ b/src-ui/src/theme_dark.scss
@@ -297,7 +297,8 @@ $border-color-dark-mode: #47494f;
     }
   }
 
-  .ng-dropdown-panel .ng-dropdown-panel-items .ng-option:hover {
+  .ng-dropdown-panel .ng-dropdown-panel-items .ng-option:hover,
+  .ng-dropdown-panel .ng-dropdown-panel-items .ng-option.ng-option-marked {
     background-color: $bg-light-dark-mode;
   }
 


### PR DESCRIPTION
Sorry for the 1 line PR but my OCD cant leave this alone. Turns out Safari has a bug that requires css transitions on `flex` property to be 'all' (took me a while to figure that out), see https://codepen.io/chriscoyier/pen/dyXqpjJ

EDIT: 
Now includes

- Fixes search field animation in Safari 😀
- Fixes dashboard widget table layout overflow issue on mobile
- Fixes ng-select highlighting with keyboard navigation in dark theme

Awesome work on the last release, amazing how much this project has added as of late!