### PR TITLE
Add gettext to  Bare Metal Route dependencies

### DIFF
--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -229,6 +229,7 @@ writing. Windows is not and will never be supported.
     *   ``python3-pip``, optionally ``pipenv`` for package installation
     *   ``python3-dev``
 
+    *   ``gettext`` for compiling interface translations
     *   ``fonts-liberation`` for generating thumbnails for plain text files
     *   ``imagemagick`` >= 6 for PDF conversion
     *   ``optipng`` for optimizing thumbnails


### PR DESCRIPTION
In theory, this package is optional since not everybody wants to compile translations.
Without other changes to step 5. (i.e. making it explicit that `python3 manage.py compilemessages` is not mandatory), not installing `gettext` results in an error when blindly copy-pasting the steps.