### PR TITLE
Allow shift-select in documents list

### DIFF
--- a/src-ui/src/app/components/document-list/document-card-large/document-card-large.component.html
+++ b/src-ui/src/app/components/document-list/document-card-large/document-card-large.component.html
@@ -1,11 +1,11 @@
 <div class="card mb-3 shadow-sm" [class.card-selected]="selected" [class.document-card]="selectable">
   <div class="row no-gutters">
     <div class="col-md-2 d-none d-lg-block doc-img-background rounded-left" [class.doc-img-background-selected]="selected">
-      <img [src]="getThumbUrl()" class="card-img doc-img border-right rounded-left" (click)="setSelected(selectable ? !selected : false)">
+      <img [src]="getThumbUrl()" class="card-img doc-img border-right rounded-left" (click)="toggleSelected.emit($event)">
 
       <div style="top: 0; left: 0" class="position-absolute border-right border-bottom bg-light p-1" [class.document-card-check]="!selected">
         <div class="custom-control custom-checkbox">
-          <input type="checkbox" class="custom-control-input" id="smallCardCheck{{document.id}}" [checked]="selected" (change)="setSelected($event.target.checked)">
+          <input type="checkbox" class="custom-control-input" id="smallCardCheck{{document.id}}" [checked]="selected" (click)="toggleSelected.emit($event)">
           <label class="custom-control-label" for="smallCardCheck{{document.id}}"></label>
         </div>
       </div>

--- a/src-ui/src/app/components/document-list/document-card-large/document-card-large.component.html
+++ b/src-ui/src/app/components/document-list/document-card-large/document-card-large.component.html
@@ -1,11 +1,11 @@
-<div class="card mb-3 shadow-sm" [class.card-selected]="selected" [class.document-card]="selectable">
+<div class="card mb-3 shadow-sm" [class.card-selected]="selected" [class.document-card]="selectable" (click)="this.toggleSelected.emit($event)">
   <div class="row no-gutters">
     <div class="col-md-2 d-none d-lg-block doc-img-background rounded-left" [class.doc-img-background-selected]="selected">
-      <img [src]="getThumbUrl()" class="card-img doc-img border-right rounded-left" (click)="toggleSelected.emit($event)">
+      <img [src]="getThumbUrl()" class="card-img doc-img border-right rounded-left">
 
       <div style="top: 0; left: 0" class="position-absolute border-right border-bottom bg-light p-1" [class.document-card-check]="!selected">
         <div class="custom-control custom-checkbox">
-          <input type="checkbox" class="custom-control-input" id="smallCardCheck{{document.id}}" [checked]="selected" (click)="toggleSelected.emit($event)">
+          <input type="checkbox" class="custom-control-input" id="smallCardCheck{{document.id}}" [checked]="selected" (click)="this.toggleSelected.emit($event)">
           <label class="custom-control-label" for="smallCardCheck{{document.id}}"></label>
         </div>
       </div>
@@ -17,11 +17,11 @@
         <div class="d-flex justify-content-between align-items-center">
           <h5 class="card-title">
             <ng-container *ngIf="document.correspondent">
-              <a *ngIf="clickCorrespondent.observers.length ; else nolink" [routerLink]="" title="Filter by correspondent" i18n-title (click)="clickCorrespondent.emit(document.correspondent)" class="font-weight-bold">{{(document.correspondent$ | async)?.name}}</a>
+              <a *ngIf="clickCorrespondent.observers.length ; else nolink" [routerLink]="" title="Filter by correspondent" i18n-title (click)="clickCorrespondent.emit(document.correspondent);$event.stopPropagation()" class="font-weight-bold">{{(document.correspondent$ | async)?.name}}</a>
               <ng-template #nolink>{{(document.correspondent$ | async)?.name}}</ng-template>:
             </ng-container>
             {{document.title | documentTitle}}
-            <app-tag [tag]="t" linkTitle="Filter by tag" i18n-linkTitle *ngFor="let t of document.tags$ | async" class="ml-1" (click)="clickTag.emit(t.id)" [clickable]="clickTag.observers.length"></app-tag>
+            <app-tag [tag]="t" linkTitle="Filter by tag" i18n-linkTitle *ngFor="let t of document.tags$ | async" class="ml-1" (click)="clickTag.emit(t.id);$event.stopPropagation()" [clickable]="clickTag.observers.length"></app-tag>
           </h5>
           <h5 class="card-title" *ngIf="document.archive_serial_number">#{{document.archive_serial_number}}</h5>
         </div>

--- a/src-ui/src/app/components/document-list/document-card-large/document-card-large.component.ts
+++ b/src-ui/src/app/components/document-list/document-card-large/document-card-large.component.ts
@@ -15,16 +15,11 @@ export class DocumentCardLargeComponent implements OnInit {
   @Input()
   selected = false
 
-  setSelected(value: boolean) {
-    this.selected = value
-    this.selectedChange.emit(value)
-  }
-
   @Output()
-  selectedChange = new EventEmitter<boolean>()
+  toggleSelected = new EventEmitter()
 
   get selectable() {
-    return this.selectedChange.observers.length > 0
+    return this.toggleSelected.observers.length > 0
   }
 
   @Input()

--- a/src-ui/src/app/components/document-list/document-card-small/document-card-small.component.html
+++ b/src-ui/src/app/components/document-list/document-card-small/document-card-small.component.html
@@ -1,18 +1,18 @@
 <div class="col p-2 h-100">
-  <div class="card h-100 shadow-sm document-card" [class.card-selected]="selected">
+  <div class="card h-100 shadow-sm document-card" [class.card-selected]="selected" (click)="this.toggleSelected.emit($event)">
     <div class="border-bottom doc-img-container" [class.doc-img-background-selected]="selected">
-      <img class="card-img doc-img rounded-top" [src]="getThumbUrl()" (click)="toggleSelected.emit($event)">
+      <img class="card-img doc-img rounded-top" [src]="getThumbUrl()">
 
       <div class="border-right border-bottom bg-light p-1 rounded document-card-check">
         <div class="custom-control custom-checkbox">
-          <input type="checkbox" class="custom-control-input" id="smallCardCheck{{document.id}}" [checked]="selected" (click)="toggleSelected.emit($event)">
+          <input type="checkbox" class="custom-control-input" id="smallCardCheck{{document.id}}" [checked]="selected" (click)="this.toggleSelected.emit($event)">
           <label class="custom-control-label" for="smallCardCheck{{document.id}}"></label>
         </div>
       </div>
 
       <div style="top: 0; right: 0; font-size: large" class="text-right position-absolute mr-1">
         <div *ngFor="let t of getTagsLimited$() | async">
-          <app-tag [tag]="t" (click)="clickTag.emit(t.id)" [clickable]="true" linkTitle="Filter by tag" i18n-linkTitle></app-tag>
+          <app-tag [tag]="t" (click)="clickTag.emit(t.id);$event.stopPropagation()" [clickable]="true" linkTitle="Filter by tag" i18n-linkTitle></app-tag>
         </div>
         <div *ngIf="moreTags">
           <span class="badge badge-secondary">+ {{moreTags}}</span>
@@ -23,7 +23,7 @@
     <div class="card-body p-2">
       <p class="card-text">
         <ng-container *ngIf="document.correspondent">
-          <a [routerLink]="" title="Filter by correspondent" i18n-title (click)="clickCorrespondent.emit(document.correspondent)" class="font-weight-bold">{{(document.correspondent$ | async)?.name}}</a>:
+          <a [routerLink]="" title="Filter by correspondent" i18n-title (click)="clickCorrespondent.emit(document.correspondent);$event.stopPropagation()" class="font-weight-bold">{{(document.correspondent$ | async)?.name}}</a>:
         </ng-container>
         {{document.title | documentTitle}} <span *ngIf="document.archive_serial_number">(#{{document.archive_serial_number}})</span>
       </p>
@@ -43,7 +43,7 @@
               <path fill-rule="evenodd" d="M6.5 12a5.5 5.5 0 1 0 0-11 5.5 5.5 0 0 0 0 11zM13 6.5a6.5 6.5 0 1 1-13 0 6.5 6.5 0 0 1 13 0z"/>
             </svg>
           </a>
-          <a [href]="getDownloadUrl()" class="btn btn-sm btn-outline-secondary" title="Download" i18n-title>
+          <a [href]="getDownloadUrl()" class="btn btn-sm btn-outline-secondary" title="Download" (click)="$event.stopPropagation()" i18n-title>
             <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-download" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
               <path fill-rule="evenodd" d="M.5 9.9a.5.5 0 0 1 .5.5v2.5a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-2.5a.5.5 0 0 1 1 0v2.5a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2v-2.5a.5.5 0 0 1 .5-.5z"/>
               <path fill-rule="evenodd" d="M7.646 11.854a.5.5 0 0 0 .708 0l3-3a.5.5 0 0 0-.708-.708L8.5 10.293V1.5a.5.5 0 0 0-1 0v8.793L5.354 8.146a.5.5 0 1 0-.708.708l3 3z"/>

--- a/src-ui/src/app/components/document-list/document-card-small/document-card-small.component.html
+++ b/src-ui/src/app/components/document-list/document-card-small/document-card-small.component.html
@@ -1,11 +1,11 @@
 <div class="col p-2 h-100">
   <div class="card h-100 shadow-sm document-card" [class.card-selected]="selected">
     <div class="border-bottom doc-img-container" [class.doc-img-background-selected]="selected">
-      <img class="card-img doc-img rounded-top" [src]="getThumbUrl()" (click)="setSelected(!selected)">
+      <img class="card-img doc-img rounded-top" [src]="getThumbUrl()" (click)="toggleSelected.emit($event)">
 
       <div class="border-right border-bottom bg-light p-1 rounded document-card-check">
         <div class="custom-control custom-checkbox">
-          <input type="checkbox" class="custom-control-input" id="smallCardCheck{{document.id}}" [checked]="selected" (change)="setSelected($event.target.checked)">
+          <input type="checkbox" class="custom-control-input" id="smallCardCheck{{document.id}}" [checked]="selected" (click)="toggleSelected.emit($event)">
           <label class="custom-control-label" for="smallCardCheck{{document.id}}"></label>
         </div>
       </div>

--- a/src-ui/src/app/components/document-list/document-card-small/document-card-small.component.ts
+++ b/src-ui/src/app/components/document-list/document-card-small/document-card-small.component.ts
@@ -14,14 +14,9 @@ export class DocumentCardSmallComponent implements OnInit {
 
   @Input()
   selected = false
-
-  setSelected(value: boolean) {
-    this.selected = value
-    this.selectedChange.emit(value)
-  }
-
+  
   @Output()
-  selectedChange = new EventEmitter<boolean>()
+  toggleSelected = new EventEmitter()
 
   @Input()
   document: PaperlessDocument

--- a/src-ui/src/app/components/document-list/document-list.component.html
+++ b/src-ui/src/app/components/document-list/document-list.component.html
@@ -135,7 +135,7 @@
       i18n>Added</th>
   </thead>
   <tbody>
-    <tr *ngFor="let d of list.documents; trackBy: trackByDocumentId" [ngClass]="list.isSelected(d) ? 'table-row-selected' : ''">
+    <tr *ngFor="let d of list.documents; trackBy: trackByDocumentId" (click)="toggleSelected(d, $event)" [ngClass]="list.isSelected(d) ? 'table-row-selected' : ''">
       <td>
         <div class="custom-control custom-checkbox">
           <input type="checkbox" class="custom-control-input" id="docCheck{{d.id}}" [checked]="list.isSelected(d)" (click)="toggleSelected(d, $event)">
@@ -147,7 +147,7 @@
       </td>
       <td class="d-none d-md-table-cell">
         <ng-container *ngIf="d.correspondent">
-          <a [routerLink]="" (click)="clickCorrespondent(d.correspondent)" title="Filter by correspondent">{{(d.correspondent$ | async)?.name}}</a>
+          <a [routerLink]="" (click)="clickCorrespondent(d.correspondent);$event.stopPropagation()" title="Filter by correspondent">{{(d.correspondent$ | async)?.name}}</a>
         </ng-container>
       </td>
       <td>
@@ -156,7 +156,7 @@
       </td>
       <td class="d-none d-xl-table-cell">
         <ng-container *ngIf="d.document_type">
-          <a [routerLink]="" (click)="clickDocumentType(d.document_type)" title="Filter by document type">{{(d.document_type$ | async)?.name}}</a>
+          <a [routerLink]="" (click)="clickDocumentType(d.document_type);$event.stopPropagation()" title="Filter by document type">{{(d.document_type$ | async)?.name}}</a>
         </ng-container>
       </td>
       <td>

--- a/src-ui/src/app/components/document-list/document-list.component.html
+++ b/src-ui/src/app/components/document-list/document-list.component.html
@@ -90,7 +90,7 @@
 </div>
 
 <div *ngIf="displayMode == 'largeCards'">
-  <app-document-card-large [selected]="list.isSelected(d)" (selectedChange)="list.setSelected(d, $event)"   *ngFor="let d of list.documents; trackBy: trackByDocumentId" [document]="d" [details]="d.content" (clickTag)="clickTag($event)" (clickCorrespondent)="clickCorrespondent($event)">
+  <app-document-card-large [selected]="list.isSelected(d)" (toggleSelected)="toggleSelected(d, $event)" *ngFor="let d of list.documents; trackBy: trackByDocumentId" [document]="d" [details]="d.content" (clickTag)="clickTag($event)" (clickCorrespondent)="clickCorrespondent($event)">
   </app-document-card-large>
 </div>
 
@@ -138,7 +138,7 @@
     <tr *ngFor="let d of list.documents; trackBy: trackByDocumentId" [ngClass]="list.isSelected(d) ? 'table-row-selected' : ''">
       <td>
         <div class="custom-control custom-checkbox">
-          <input type="checkbox" class="custom-control-input" id="docCheck{{d.id}}" [checked]="list.isSelected(d)" (change)="list.setSelected(d, $event.target.checked)">
+          <input type="checkbox" class="custom-control-input" id="docCheck{{d.id}}" [checked]="list.isSelected(d)" (click)="toggleSelected(d, $event)">
           <label class="custom-control-label" for="docCheck{{d.id}}"></label>
         </div>
       </td>
@@ -170,5 +170,5 @@
 </table>
 
 <div class="m-n2 row row-cols-paperless-cards" *ngIf="displayMode == 'smallCards'">
-  <app-document-card-small [selected]="list.isSelected(d)" (selectedChange)="list.setSelected(d, $event)"  [document]="d" *ngFor="let d of list.documents; trackBy: trackByDocumentId" (clickTag)="clickTag($event)" (clickCorrespondent)="clickCorrespondent($event)"></app-document-card-small>
+  <app-document-card-small [selected]="list.isSelected(d)" (toggleSelected)="toggleSelected(d, $event)"  [document]="d" *ngFor="let d of list.documents; trackBy: trackByDocumentId" (clickTag)="clickTag($event)" (clickCorrespondent)="clickCorrespondent($event)"></app-document-card-small>
 </div>

--- a/src-ui/src/app/components/document-list/document-list.component.scss
+++ b/src-ui/src/app/components/document-list/document-list.component.scss
@@ -1,5 +1,9 @@
 @import "/src/theme";
 
+tr {
+  user-select: none;
+}
+
 .table-row-selected {
   background-color: $primaryFaded;
 }

--- a/src-ui/src/app/components/document-list/document-list.component.ts
+++ b/src-ui/src/app/components/document-list/document-list.component.ts
@@ -161,7 +161,8 @@ export class DocumentListComponent implements OnInit {
   }
 
   toggleSelected(document: PaperlessDocument, event: MouseEvent): void {
-    this.list.toggleSelected(document, event.shiftKey)
+    if (!event.shiftKey) this.list.toggleSelected(document)
+    else this.list.selectRangeTo(document)
   }
 
   clickTag(tagID: number) {

--- a/src-ui/src/app/components/document-list/document-list.component.ts
+++ b/src-ui/src/app/components/document-list/document-list.component.ts
@@ -160,6 +160,10 @@ export class DocumentListComponent implements OnInit {
     this.filterRulesModified = modified
   }
 
+  toggleSelected(document: PaperlessDocument, event: Event): void {
+    this.list.toggleSelected(document)
+  }
+
   clickTag(tagID: number) {
     this.list.selectNone()
     setTimeout(() => {

--- a/src-ui/src/app/components/document-list/document-list.component.ts
+++ b/src-ui/src/app/components/document-list/document-list.component.ts
@@ -160,8 +160,8 @@ export class DocumentListComponent implements OnInit {
     this.filterRulesModified = modified
   }
 
-  toggleSelected(document: PaperlessDocument, event: Event): void {
-    this.list.toggleSelected(document)
+  toggleSelected(document: PaperlessDocument, event: MouseEvent): void {
+    this.list.toggleSelected(document, event.shiftKey)
   }
 
   clickTag(tagID: number) {

--- a/src-ui/src/app/services/document-list-view.service.ts
+++ b/src-ui/src/app/services/document-list-view.service.ts
@@ -253,19 +253,21 @@ export class DocumentListViewService {
     return this.selected.has(d.id)
   }
 
-  toggleSelected(d: PaperlessDocument, includeRange: boolean): void {
-    if (!includeRange) {
-      // regular i.e. no shift key toggle
-      if (this.selected.has(d.id)) this.selected.delete(d.id)
-      else this.selected.add(d.id)
-    } else if (includeRange && this.lastSelectedDocumentIndex !== null) {
+  toggleSelected(d: PaperlessDocument): void {
+    if (this.selected.has(d.id)) this.selected.delete(d.id)
+    else this.selected.add(d.id)
+    this.lastSelectedDocumentIndex = this.documentIndexInCurrentView(d.id)
+  }
+
+  selectRangeTo(d: PaperlessDocument) {
+    if (this.lastSelectedDocumentIndex !== null) {
       const documentToIndex = this.documentIndexInCurrentView(d.id)
       const fromIndex = Math.min(this.lastSelectedDocumentIndex, documentToIndex)
       const toIndex = Math.max(this.lastSelectedDocumentIndex, documentToIndex)
 
       if ((this.lastSelectedDocumentToIndex > this.lastSelectedDocumentIndex && documentToIndex < this.lastSelectedDocumentIndex) ||
           (this.lastSelectedDocumentToIndex < this.lastSelectedDocumentIndex && documentToIndex > this.lastSelectedDocumentIndex)) {
-          // invert last selected
+          // new click is "opposite side" of anchor so we invert the old selection
           this.documents.slice(Math.min(this.lastSelectedDocumentIndex, this.lastSelectedDocumentToIndex), Math.max(this.lastSelectedDocumentIndex, this.lastSelectedDocumentToIndex) + 1).forEach(d => {
             this.selected.delete(d.id)
           })
@@ -275,9 +277,7 @@ export class DocumentListViewService {
         this.selected.add(d.id)
       })
       this.lastSelectedDocumentToIndex = documentToIndex
-    }
-
-    if (!includeRange || (includeRange && this.lastSelectedDocumentIndex == null)) { // e.g. shift key but first click
+    } else { // e.g. shift key but was first click
       this.lastSelectedDocumentIndex = this.documentIndexInCurrentView(d.id)
     }
   }

--- a/src-ui/src/app/services/document-list-view.service.ts
+++ b/src-ui/src/app/services/document-list-view.service.ts
@@ -27,8 +27,8 @@ export class DocumentListViewService {
   currentPage = 1
   currentPageSize: number = this.settings.get(SETTINGS_KEYS.DOCUMENT_LIST_SIZE)
   collectionSize: number
-  lastSelectedDocumentIndex: number
-  lastSelectedDocumentToIndex: number
+  rangeSelectionAnchorIndex: number
+  lastRangeSelectionToIndex: number
 
   /**
    * This is the current config for the document list. The service will always remember the last settings used for the document list.
@@ -110,7 +110,7 @@ export class DocumentListViewService {
           if (onFinish) {
             onFinish()
           }
-          this.lastSelectedDocumentIndex = this.lastSelectedDocumentToIndex = null
+          this.rangeSelectionAnchorIndex = this.lastRangeSelectionToIndex = null
           this.isReloading = false
         },
         error => {
@@ -221,7 +221,7 @@ export class DocumentListViewService {
 
   selectNone() {
     this.selected.clear()
-    this.lastSelectedDocumentIndex = this.lastSelectedDocumentToIndex = null
+    this.rangeSelectionAnchorIndex = this.lastRangeSelectionToIndex = null
   }
 
   reduceSelectionToFilter() {
@@ -256,22 +256,22 @@ export class DocumentListViewService {
   toggleSelected(d: PaperlessDocument): void {
     if (this.selected.has(d.id)) this.selected.delete(d.id)
     else this.selected.add(d.id)
-    this.lastSelectedDocumentIndex = this.documentIndexInCurrentView(d.id)
-    this.lastSelectedDocumentToIndex = null
+    this.rangeSelectionAnchorIndex = this.documentIndexInCurrentView(d.id)
+    this.lastRangeSelectionToIndex = null
   }
 
   selectRangeTo(d: PaperlessDocument) {
-    if (this.lastSelectedDocumentIndex !== null) {
+    if (this.rangeSelectionAnchorIndex !== null) {
       const documentToIndex = this.documentIndexInCurrentView(d.id)
-      const fromIndex = Math.min(this.lastSelectedDocumentIndex, documentToIndex)
-      const toIndex = Math.max(this.lastSelectedDocumentIndex, documentToIndex)
+      const fromIndex = Math.min(this.rangeSelectionAnchorIndex, documentToIndex)
+      const toIndex = Math.max(this.rangeSelectionAnchorIndex, documentToIndex)
 
-      if (this.lastSelectedDocumentToIndex !== null &&
-          ((this.lastSelectedDocumentToIndex > this.lastSelectedDocumentIndex && documentToIndex <= this.lastSelectedDocumentIndex) ||
-          (this.lastSelectedDocumentToIndex < this.lastSelectedDocumentIndex && documentToIndex >= this.lastSelectedDocumentIndex))) {
+      if (this.lastRangeSelectionToIndex !== null &&
+          ((this.lastRangeSelectionToIndex > this.rangeSelectionAnchorIndex && documentToIndex <= this.rangeSelectionAnchorIndex) ||
+          (this.lastRangeSelectionToIndex < this.rangeSelectionAnchorIndex && documentToIndex >= this.rangeSelectionAnchorIndex))) {
 
         // new click is "opposite side" of anchor so we invert the old selection
-        this.documents.slice(Math.min(this.lastSelectedDocumentIndex, this.lastSelectedDocumentToIndex), Math.max(this.lastSelectedDocumentIndex, this.lastSelectedDocumentToIndex) + 1).forEach(d => {
+        this.documents.slice(Math.min(this.rangeSelectionAnchorIndex, this.lastRangeSelectionToIndex), Math.max(this.rangeSelectionAnchorIndex, this.lastRangeSelectionToIndex) + 1).forEach(d => {
           this.selected.delete(d.id)
         })
       }
@@ -279,7 +279,7 @@ export class DocumentListViewService {
       this.documents.slice(fromIndex, toIndex + 1).forEach(d => {
         this.selected.add(d.id)
       })
-      this.lastSelectedDocumentToIndex = documentToIndex
+      this.lastRangeSelectionToIndex = documentToIndex
     } else { // e.g. shift key but was first click
       this.toggleSelected(d)
     }

--- a/src-ui/src/app/services/document-list-view.service.ts
+++ b/src-ui/src/app/services/document-list-view.service.ts
@@ -255,6 +255,9 @@ export class DocumentListViewService {
     } else if (!value) {
       this.selected.delete(d.id)
     }
+  toggleSelected(d: PaperlessDocument): void {
+    if (this.selected.has(d.id)) this.selected.delete(d.id)
+    else this.selected.add(d.id)
   }
 
   constructor(private documentService: DocumentService, private settings: SettingsService, private router: Router) {

--- a/src-ui/src/app/services/document-list-view.service.ts
+++ b/src-ui/src/app/services/document-list-view.service.ts
@@ -267,9 +267,8 @@ export class DocumentListViewService {
       const toIndex = Math.max(this.lastSelectedDocumentIndex, documentToIndex)
 
       if (this.lastSelectedDocumentToIndex !== null &&
-          ((this.lastSelectedDocumentToIndex > this.lastSelectedDocumentIndex && documentToIndex < this.lastSelectedDocumentIndex) ||
-          (this.lastSelectedDocumentToIndex < this.lastSelectedDocumentIndex && documentToIndex > this.lastSelectedDocumentIndex))) {
-        console.log('invert');
+          ((this.lastSelectedDocumentToIndex > this.lastSelectedDocumentIndex && documentToIndex <= this.lastSelectedDocumentIndex) ||
+          (this.lastSelectedDocumentToIndex < this.lastSelectedDocumentIndex && documentToIndex >= this.lastSelectedDocumentIndex))) {
 
         // new click is "opposite side" of anchor so we invert the old selection
         this.documents.slice(Math.min(this.lastSelectedDocumentIndex, this.lastSelectedDocumentToIndex), Math.max(this.lastSelectedDocumentIndex, this.lastSelectedDocumentToIndex) + 1).forEach(d => {
@@ -282,7 +281,7 @@ export class DocumentListViewService {
       })
       this.lastSelectedDocumentToIndex = documentToIndex
     } else { // e.g. shift key but was first click
-      this.lastSelectedDocumentIndex = this.documentIndexInCurrentView(d.id)
+      this.toggleSelected(d)
     }
   }
 

--- a/src-ui/src/app/services/document-list-view.service.ts
+++ b/src-ui/src/app/services/document-list-view.service.ts
@@ -258,7 +258,6 @@ export class DocumentListViewService {
 
     if (includeRange && this.lastSelectedDocumentIndex !== null) {
       const toIndex = this.documentIndexInCurrentView(d.id)
-      console.log('select from', this.lastSelectedDocumentIndex, 'to', toIndex);
       this.documents.slice(Math.min(this.lastSelectedDocumentIndex, toIndex), Math.max(this.lastSelectedDocumentIndex, toIndex)).forEach(d => {
         this.selected.add(d.id)
       })

--- a/src-ui/src/app/services/document-list-view.service.ts
+++ b/src-ui/src/app/services/document-list-view.service.ts
@@ -269,7 +269,6 @@ export class DocumentListViewService {
       if (this.lastRangeSelectionToIndex !== null &&
           ((this.lastRangeSelectionToIndex > this.rangeSelectionAnchorIndex && documentToIndex <= this.rangeSelectionAnchorIndex) ||
           (this.lastRangeSelectionToIndex < this.rangeSelectionAnchorIndex && documentToIndex >= this.rangeSelectionAnchorIndex))) {
-
         // new click is "opposite side" of anchor so we invert the old selection
         this.documents.slice(Math.min(this.rangeSelectionAnchorIndex, this.lastRangeSelectionToIndex), Math.max(this.rangeSelectionAnchorIndex, this.lastRangeSelectionToIndex) + 1).forEach(d => {
           this.selected.delete(d.id)

--- a/src-ui/src/app/services/document-list-view.service.ts
+++ b/src-ui/src/app/services/document-list-view.service.ts
@@ -266,10 +266,8 @@ export class DocumentListViewService {
       const fromIndex = Math.min(this.rangeSelectionAnchorIndex, documentToIndex)
       const toIndex = Math.max(this.rangeSelectionAnchorIndex, documentToIndex)
 
-      if (this.lastRangeSelectionToIndex !== null &&
-          ((this.lastRangeSelectionToIndex > this.rangeSelectionAnchorIndex && documentToIndex <= this.rangeSelectionAnchorIndex) ||
-          (this.lastRangeSelectionToIndex < this.rangeSelectionAnchorIndex && documentToIndex >= this.rangeSelectionAnchorIndex))) {
-        // new click is "opposite side" of anchor so we invert the old selection
+      if (this.lastRangeSelectionToIndex !== null) {
+        // revert the old selection
         this.documents.slice(Math.min(this.rangeSelectionAnchorIndex, this.lastRangeSelectionToIndex), Math.max(this.rangeSelectionAnchorIndex, this.lastRangeSelectionToIndex) + 1).forEach(d => {
           this.selected.delete(d.id)
         })

--- a/src-ui/src/app/services/document-list-view.service.ts
+++ b/src-ui/src/app/services/document-list-view.service.ts
@@ -257,6 +257,7 @@ export class DocumentListViewService {
     if (this.selected.has(d.id)) this.selected.delete(d.id)
     else this.selected.add(d.id)
     this.lastSelectedDocumentIndex = this.documentIndexInCurrentView(d.id)
+    this.lastSelectedDocumentToIndex = null
   }
 
   selectRangeTo(d: PaperlessDocument) {
@@ -265,12 +266,15 @@ export class DocumentListViewService {
       const fromIndex = Math.min(this.lastSelectedDocumentIndex, documentToIndex)
       const toIndex = Math.max(this.lastSelectedDocumentIndex, documentToIndex)
 
-      if ((this.lastSelectedDocumentToIndex > this.lastSelectedDocumentIndex && documentToIndex < this.lastSelectedDocumentIndex) ||
-          (this.lastSelectedDocumentToIndex < this.lastSelectedDocumentIndex && documentToIndex > this.lastSelectedDocumentIndex)) {
-          // new click is "opposite side" of anchor so we invert the old selection
-          this.documents.slice(Math.min(this.lastSelectedDocumentIndex, this.lastSelectedDocumentToIndex), Math.max(this.lastSelectedDocumentIndex, this.lastSelectedDocumentToIndex) + 1).forEach(d => {
-            this.selected.delete(d.id)
-          })
+      if (this.lastSelectedDocumentToIndex !== null &&
+          ((this.lastSelectedDocumentToIndex > this.lastSelectedDocumentIndex && documentToIndex < this.lastSelectedDocumentIndex) ||
+          (this.lastSelectedDocumentToIndex < this.lastSelectedDocumentIndex && documentToIndex > this.lastSelectedDocumentIndex))) {
+        console.log('invert');
+
+        // new click is "opposite side" of anchor so we invert the old selection
+        this.documents.slice(Math.min(this.lastSelectedDocumentIndex, this.lastSelectedDocumentToIndex), Math.max(this.lastSelectedDocumentIndex, this.lastSelectedDocumentToIndex) + 1).forEach(d => {
+          this.selected.delete(d.id)
+        })
       }
 
       this.documents.slice(fromIndex, toIndex + 1).forEach(d => {


### PR DESCRIPTION
This PR closes #347 and adds support for "shift-click" to select multiple documents. A couple notes @jonaswinkler because I know you run a tight ship:

  1. I moved all selection functions out of the cards partly to be able to detect shift key when clicking (e.g. from `MouseEvent`) but also they seemed redundant since cards/`tr`s have an input to determine selection like `[selected]="list.isSelected(d)"`
2. I also updated cards & `tr`s to allow clicking anywhere on the item (e.g. entire card or anywhere in the `tr`. This feels like it makes more sense UI-wise (also since the checkbox shows on hovering the entire card it is kind a tiny 'bug' that you could hover but not click) but let me know if you think otherwise.
3. Selecting mimics what I saw in other systems. For example if you reverse the direction, previous items un-select e.g. if you start by clicking 5, shift click to 10 (selecting range 5-10) then click 1, 5-10 becomes _de-selected_ and 1-5 become selected.
4. As you said, shift-clicking resets when changing pages.

Let me know if you notice any issues!