### PR TITLE
Ansible - Fix uvicorn dependency issue for >1.0.0

### DIFF
--- a/ansible/tasks/main.yml
+++ b/ansible/tasks/main.yml
@@ -488,11 +488,14 @@
     value: "{{ paperlessng_virtualenv }}/bin/python3 manage.py qcluster"
 
 - name: configure paperless-webserver service
+  vars:
+    ExecStart_value: |
+      {{ paperlessng_virtualenv }}/bin/gunicorn paperless.asgi:application -w 2 {{ '' if paperlessng_version == '1.0.0' else '-k uvicorn.workers.UvicornWorker '}}-b {{ paperlessng_listen_address }}:{{ paperlessng_listen_port }}
   ini_file:
     path: "{{ paperlessng_directory }}/scripts/paperless-webserver.service"
     section: "Service"
     option: "ExecStart"
-    value: "{{ paperlessng_virtualenv }}/bin/gunicorn paperless.asgi:application -w 2 -k uvicorn.workers.UvicornWorker -b {{ paperlessng_listen_address }}:{{ paperlessng_listen_port }}"
+    value: "{{ ExecStart_value | trim }}"
 
 - name: copy systemd services
   copy:

--- a/ansible/tasks/main.yml
+++ b/ansible/tasks/main.yml
@@ -490,7 +490,7 @@
 - name: configure paperless-webserver service
   vars:
     ExecStart_value: |
-      {{ paperlessng_virtualenv }}/bin/gunicorn paperless.asgi:application -w 2 {{ '' if paperlessng_version == '1.0.0' else '-k uvicorn.workers.UvicornWorker '}}-b {{ paperlessng_listen_address }}:{{ paperlessng_listen_port }}
+      {{ paperlessng_virtualenv }}/bin/gunicorn {{ 'paperless.wsgi' if paperlessng_version == '1.0.0' else 'paperless.asgi:application' }} -w 2 {{ '' if paperlessng_version == '1.0.0' else '-k uvicorn.workers.UvicornWorker '}}-b {{ paperlessng_listen_address }}:{{ paperlessng_listen_port }}
   ini_file:
     path: "{{ paperlessng_directory }}/scripts/paperless-webserver.service"
     section: "Service"


### PR DESCRIPTION
Note that this is a very crude fix for your current development.
I would highly recommend using a more advanced version check than `version == '1.0.0'`.