### PR TITLE
Use sidecar to extract parsed contents

### DIFF
--- a/src/paperless_tesseract/parsers.py
+++ b/src/paperless_tesseract/parsers.py
@@ -114,6 +114,7 @@ class RasterisedDocumentParser(DocumentParser):
             mode = "redo"
 
         archive_path = os.path.join(self.tempdir, "archive.pdf")
+        sidecar_path = os.path.join(self.tempdir, "contents.txt")
 
         ocr_args = {
             'input_file': document_path,
@@ -123,7 +124,8 @@ class RasterisedDocumentParser(DocumentParser):
             'language': settings.OCR_LANGUAGE,
             'output_type': settings.OCR_OUTPUT_TYPE,
             'progress_bar': False,
-            'clean': True
+            'clean': True,
+            'sidecar': sidecar_path,
         }
 
         if settings.OCR_PAGES > 0:
@@ -179,7 +181,8 @@ class RasterisedDocumentParser(DocumentParser):
             ocrmypdf.ocr(**ocr_args)
             # success! announce results
             self.archive_path = archive_path
-            self.text = get_text_from_pdf(archive_path)
+            with open(sidecar_path) as f:
+                self.text = f.read()
 
         except (InputFileError, EncryptedPdfError) as e:
 


### PR DESCRIPTION
OCRmyPDF can export the parsed text into a separate text file, so the
contents can be directly accessible.
Reading the contents from PDF gets them after tesseract does layouting
which leads to bad results in Hebrew, and possibly other RTL languages.

Getting the contents from the sidecar is both simpler and more robust.