### PR TITLE
Ansible - Improve CI stability

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -47,7 +47,6 @@ jobs:
           molecule converge
           molecule idempotence
           molecule verify
-          molecule destroy
         working-directory: "${{ github.repository }}"
   # # https://galaxy.ansible.com/docs/contributing/importing.html
   # release:

--- a/ansible/molecule/default/converge.yml
+++ b/ansible/molecule/default/converge.yml
@@ -2,9 +2,15 @@
 - name: update previous release to newest release
   hosts: all
   tasks:
+    - name: install git dependency
+      apt:
+        pkg: git
+    - name: obtain latest git hash in current tree
+      command: git rev-parse HEAD
+      register: git_hash
     - name: set current github commit as version when available
       set_fact:
-        paperlessng_version: "{{ lookup('env', 'GITHUB_SHA') | default('master', True) }}"
+        paperlessng_version: "{{ git_hash.stdout }}"
     - name: update to newest paperless-ng release
       include_role:
         name: ansible


### PR DESCRIPTION
Do not require molecule teardown for success.

CI failures should not be caused by intermittently failing docker
communication furing test teardown.