### PR TITLE
Ansible - Fix GitHub actions

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -48,6 +48,8 @@ jobs:
           molecule idempotence
           molecule verify
         working-directory: "${{ github.repository }}"
+        env:
+          TARGET_GITHUB_SHA: "${{ github.event.pull_request.head.sha }}"
   # # https://galaxy.ansible.com/docs/contributing/importing.html
   # release:
   #   runs-on: ubuntu-latest

--- a/ansible/molecule/default/converge.yml
+++ b/ansible/molecule/default/converge.yml
@@ -2,15 +2,9 @@
 - name: update previous release to newest release
   hosts: all
   tasks:
-    - name: install git dependency
-      apt:
-        pkg: git
-    - name: obtain latest git hash in current tree
-      command: git rev-parse HEAD
-      register: git_hash
     - name: set current github commit as version when available
       set_fact:
-        paperlessng_version: "{{ git_hash.stdout }}"
+        paperlessng_version: "{{ lookup('env', 'TARGET_GITHUB_SHA') | default('master', True) }}"
     - name: update to newest paperless-ng release
       include_role:
         name: ansible


### PR DESCRIPTION
Follow-up to #630.
The check for the target git sha does not work in the molecule step.
Instead expose the sha through an env variable in GitHub actions.

This addresses the issue of re-running GitHub actions workflows as explained in https://github.com/jonaswinkler/paperless-ng/pull/602#issuecomment-785261225.