### PR TITLE
Postgres won't run without a password.

### DIFF
--- a/scripts/start_services.sh
+++ b/scripts/start_services.sh
@@ -1,4 +1,4 @@
-docker run -p 5432:5432 -v paperless_pgdata:/var/lib/postgresql/data -d postgres:13
+docker run -p 5432:5432 -e POSTGRES_PASSWORD=password -v paperless_pgdata:/var/lib/postgresql/data -d postgres:13
 docker run -d -p 6379:6379 redis:latest
 docker run -p 3000:3000 -d thecodingmachine/gotenberg
 docker run -p 9998:9998 -d apache/tika


### PR DESCRIPTION
Postgres needs a superuser password when running with an un-initialized database.

After running the start_services.sh script, I noticed that the Postgres container wasn't running. 

Upon inspecting the logs of the container, I could see the following message:

```
Error: Database is uninitialized and superuser password is not specified.
       You must specify POSTGRES_PASSWORD to a non-empty value for the
       superuser. For example, "-e POSTGRES_PASSWORD=password" on "docker run".

       You may also use "POSTGRES_HOST_AUTH_METHOD=trust" to allow all
       connections without a password. This is *not* recommended.

       See PostgreSQL documentation about "trust":
       https://www.postgresql.org/docs/current/auth-trust.html
```

This change just adds a password so that the DB can run.