### PR TITLE
Installation Script: Check for Docker permissions on startup

### DIFF
--- a/install-paperless-ng.sh
+++ b/install-paperless-ng.sh
@@ -68,8 +68,8 @@ fi
 # If this fails, the user probably does not have permissions for Docker.
 docker stats --no-stream 2>/dev/null 1>&2
 if [ $? -ne 0 ] ; then
-  echo ""
-  echo "WARN: It look like the current user does not have Docker permissions."
+	echo ""
+	echo "WARN: It look like the current user does not have Docker permissions."
 	echo "WARN: Use 'sudo usermod -aG docker $USER' to assign Docker permissions to the user."
 	echo ""
 	sleep 3

--- a/install-paperless-ng.sh
+++ b/install-paperless-ng.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -e
-
 ask() {
 	while true ; do
 		if [[ -z $3 ]] ; then
@@ -74,6 +72,8 @@ if [ $? -ne 0 ] ; then
 	echo ""
 	sleep 3
 fi
+
+set -e
 
 echo ""
 echo "############################################"

--- a/install-paperless-ng.sh
+++ b/install-paperless-ng.sh
@@ -64,6 +64,17 @@ if [[ -z $(which docker-compose) ]] ; then
 	exit 1
 fi
 
+# Check if user has permissions to run Docker by trying to get the status of Docker (docker status). 
+# If this fails, the user probably does not have permissions for Docker.
+docker stats --no-stream 2>/dev/null 1>&2
+if [ $? -ne 0 ] ; then
+  echo ""
+  echo "WARN: It look like the current user does not have Docker permissions."
+	echo "WARN: Use 'sudo usermod -aG docker $USER' to assign Docker permissions to the user."
+	echo ""
+	sleep 3
+fi
+
 echo ""
 echo "############################################"
 echo "###   Paperless-ng docker installation   ###"


### PR DESCRIPTION
Refers to: #686 

The install script does not check if a user has the necessary permissions to run Docker (-Compose). The documentation also does not describe further how to give a non-root user permissions to Docker. At least, I did not see such a description at first glance. Therefore, I implemented a check that verifies if a user has the required Docker permissions. 

For this purpose, when starting the script, it tries to call `docker status --no-stream`.  
If a user has the required permissions, it exits with status 0, otherwise 1.

If a user has no Docker permissions, the following message is displayed and the script is stopped for 3 seconds:
```bash
noperm@test:~$ ./install-paperless-ng.sh

WARN: It look like the current user does not have Docker permissions.
WARN: Use 'sudo usermod -aG docker hafnskl' to assign Docker permissions to the user.


############################################
###   Paperless-ng docker installation   ###
###########################################
```