### PR TITLE
Implemented 'Filter by: ASN'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![ci](https://github.com/jonaswinkler/paperless-ng/workflows/ci/badge.svg)](https://github.com/jonaswinkler/paperless-ng/actions)
 ![Ansible Role](https://github.com/jonaswinkler/paperless-ng/workflows/Ansible%20Role/badge.svg)
+[![Crowdin](https://badges.crowdin.net/paperless-ng/localized.svg)](https://crowdin.com/project/paperless-ng)
 [![Documentation Status](https://readthedocs.org/projects/paperless-ng/badge/?version=latest)](https://paperless-ng.readthedocs.io/en/latest/?badge=latest)
 [![Gitter](https://badges.gitter.im/paperless-ng/community.svg)](https://gitter.im/paperless-ng/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Docker Hub Pulls](https://img.shields.io/docker/pulls/jonaswinkler/paperless-ng.svg)](https://hub.docker.com/r/jonaswinkler/paperless-ng)

--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ The documentation for Paperless-ng is available on [ReadTheDocs](https://paperle
 
 # Translation
 
-Paperless is currently available in English, German, Dutch, French, and Portuguese.
+Paperless is currently available in English, German, Dutch, French, Portuguese, Italian, and Romanian.
 
-There's an active translation project at transifex! If you want to help out by translating paperless into your language, please head over to https://github.com/jonaswinkler/paperless-ng/issues/212 for details.
+There's an active translation project at crowdin! If you want to help out by translating paperless into your language, please head over to https://github.com/jonaswinkler/paperless-ng/issues/212 for details.
 
 # Feature Requests
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,6 +16,8 @@ This release contains new database migrations.
 
   * Added a color picker for tag colors.
 
+  * Added the ability to use the filter for searching the document content as well.
+
   * Added translations into Italian and Romanian. Thank you!
 
   * Close individual documents from the sidebar. Thanks to `Michael Shamoon`_.

--- a/src-ui/messages.xlf
+++ b/src-ui/messages.xlf
@@ -1043,63 +1043,77 @@
         <source>Title</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/document-list/filter-editor/filter-editor.component.ts</context>
-          <context context-type="linenumber">73</context>
+          <context context-type="linenumber">77</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3100631071441658964" datatype="html">
         <source>Title &amp; content</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/document-list/filter-editor/filter-editor.component.ts</context>
-          <context context-type="linenumber">74</context>
+          <context context-type="linenumber">78</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7517688192215738656" datatype="html">
+        <source>ASN</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/document-list/filter-editor/filter-editor.component.ts</context>
+          <context context-type="linenumber">79</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5195932016807797291" datatype="html">
         <source>Correspondent: <x id="PH" equiv-text="this.correspondents.find(c =&gt; c.id == +rule.value)?.name"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/document-list/filter-editor/filter-editor.component.ts</context>
-          <context context-type="linenumber">32</context>
+          <context context-type="linenumber">33</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8170755470576301659" datatype="html">
         <source>Without correspondent</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/document-list/filter-editor/filter-editor.component.ts</context>
-          <context context-type="linenumber">34</context>
+          <context context-type="linenumber">35</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8705701325879965907" datatype="html">
         <source>Type: <x id="PH" equiv-text="this.documentTypes.find(dt =&gt; dt.id == +rule.value)?.name"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/document-list/filter-editor/filter-editor.component.ts</context>
-          <context context-type="linenumber">39</context>
+          <context context-type="linenumber">40</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4362173610367509215" datatype="html">
         <source>Without document type</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/document-list/filter-editor/filter-editor.component.ts</context>
-          <context context-type="linenumber">41</context>
+          <context context-type="linenumber">42</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8180755793012580465" datatype="html">
         <source>Tag: <x id="PH" equiv-text="this.tags.find(t =&gt; t.id == +rule.value)?.name"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/document-list/filter-editor/filter-editor.component.ts</context>
-          <context context-type="linenumber">45</context>
+          <context context-type="linenumber">46</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6494566478302448576" datatype="html">
         <source>Without any tag</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/document-list/filter-editor/filter-editor.component.ts</context>
-          <context context-type="linenumber">49</context>
+          <context context-type="linenumber">50</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6523384805359286307" datatype="html">
         <source>Title: <x id="PH" equiv-text="rule.value"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/components/document-list/filter-editor/filter-editor.component.ts</context>
-          <context context-type="linenumber">53</context>
+          <context context-type="linenumber">54</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1872523635812236432" datatype="html">
+        <source>ASN: <x id="PH" equiv-text="rule.value"/></source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/components/document-list/filter-editor/filter-editor.component.ts</context>
+          <context context-type="linenumber">57</context>
         </context-group>
       </trans-unit>
       <trans-unit id="02d184c288f567825a1fcbf83bcd3099a10853d5" datatype="html">
@@ -1817,13 +1831,6 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/services/toast.service.ts</context>
           <context context-type="linenumber">39</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="7517688192215738656" datatype="html">
-        <source>ASN</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/services/rest/document.service.ts</context>
-          <context context-type="linenumber">17</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2691296884221415710" datatype="html">

--- a/src-ui/src/app/components/document-list/filter-editor/filter-editor.component.ts
+++ b/src-ui/src/app/components/document-list/filter-editor/filter-editor.component.ts
@@ -8,12 +8,13 @@ import { DocumentTypeService } from 'src/app/services/rest/document-type.service
 import { TagService } from 'src/app/services/rest/tag.service';
 import { CorrespondentService } from 'src/app/services/rest/correspondent.service';
 import { FilterRule } from 'src/app/data/filter-rule';
-import { FILTER_ADDED_AFTER, FILTER_ADDED_BEFORE, FILTER_CORRESPONDENT, FILTER_CREATED_AFTER, FILTER_CREATED_BEFORE, FILTER_DOCUMENT_TYPE, FILTER_HAS_ANY_TAG, FILTER_HAS_TAG, FILTER_TITLE, FILTER_TITLE_CONTENT } from 'src/app/data/filter-rule-type';
+import { FILTER_ADDED_AFTER, FILTER_ADDED_BEFORE, FILTER_ASN, FILTER_CORRESPONDENT, FILTER_CREATED_AFTER, FILTER_CREATED_BEFORE, FILTER_DOCUMENT_TYPE, FILTER_HAS_ANY_TAG, FILTER_HAS_TAG, FILTER_TITLE, FILTER_TITLE_CONTENT } from 'src/app/data/filter-rule-type';
 import { FilterableDropdownSelectionModel } from '../../common/filterable-dropdown/filterable-dropdown.component';
 import { ToggleableItemState } from '../../common/filterable-dropdown/toggleable-dropdown-button/toggleable-dropdown-button.component';
 
 const TEXT_FILTER_TARGET_TITLE = "title"
 const TEXT_FILTER_TARGET_TITLE_CONTENT = "title-content"
+const TEXT_FILTER_TARGET_ASN = "asn"
 
 @Component({
   selector: 'app-filter-editor',
@@ -51,6 +52,9 @@ export class FilterEditorComponent implements OnInit, OnDestroy {
 
         case FILTER_TITLE:
           return $localize`Title: ${rule.value}`
+
+        case FILTER_ASN:
+          return $localize`ASN: ${rule.value}`
       }
     }
 
@@ -71,7 +75,8 @@ export class FilterEditorComponent implements OnInit, OnDestroy {
 
   textFilterTargets = [
     {id: TEXT_FILTER_TARGET_TITLE, name: $localize`Title`},
-    {id: TEXT_FILTER_TARGET_TITLE_CONTENT, name: $localize`Title & content`}
+    {id: TEXT_FILTER_TARGET_TITLE_CONTENT, name: $localize`Title & content`},
+    {id: TEXT_FILTER_TARGET_ASN, name: $localize`ASN`}
   ]
 
   textFilterTarget = TEXT_FILTER_TARGET_TITLE_CONTENT
@@ -111,6 +116,10 @@ export class FilterEditorComponent implements OnInit, OnDestroy {
           this._textFilter = rule.value
           this.textFilterTarget = TEXT_FILTER_TARGET_TITLE_CONTENT
           break
+        case FILTER_ASN:
+          this._textFilter = rule.value
+          this.textFilterTarget = TEXT_FILTER_TARGET_ASN
+          break
         case FILTER_CREATED_AFTER:
           this.dateCreatedAfter = rule.value
           break
@@ -146,6 +155,9 @@ export class FilterEditorComponent implements OnInit, OnDestroy {
     }
     if (this._textFilter && this.textFilterTarget == TEXT_FILTER_TARGET_TITLE) {
       filterRules.push({rule_type: FILTER_TITLE, value: this._textFilter})
+    }
+    if (this._textFilter && this.textFilterTarget == TEXT_FILTER_TARGET_ASN) {
+      filterRules.push({rule_type: FILTER_ASN, value: this._textFilter})
     }
     if (this.tagSelectionModel.isNoneSelected()) {
       filterRules.push({rule_type: FILTER_HAS_ANY_TAG, value: "false"})

--- a/src/documents/tests/test_api.py
+++ b/src/documents/tests/test_api.py
@@ -270,6 +270,30 @@ class TestDocumentApi(DirectoriesMixin, APITestCase):
         results = response.data['results']
         self.assertEqual(len(results), 0)
 
+    def test_documents_title_content_filter(self):
+
+        doc1 = Document.objects.create(title="title A", content="content A", checksum="A", mime_type="application/pdf")
+        doc2 = Document.objects.create(title="title B", content="content A", checksum="B", mime_type="application/pdf")
+        doc3 = Document.objects.create(title="title A", content="content B", checksum="C", mime_type="application/pdf")
+        doc4 = Document.objects.create(title="title B", content="content B", checksum="D", mime_type="application/pdf")
+
+        response = self.client.get("/api/documents/?title_content=A")
+        self.assertEqual(response.status_code, 200)
+        results = response.data['results']
+        self.assertEqual(len(results), 3)
+        self.assertCountEqual([results[0]['id'], results[1]['id'], results[2]['id']], [doc1.id, doc2.id, doc3.id])
+
+        response = self.client.get("/api/documents/?title_content=B")
+        self.assertEqual(response.status_code, 200)
+        results = response.data['results']
+        self.assertEqual(len(results), 3)
+        self.assertCountEqual([results[0]['id'], results[1]['id'], results[2]['id']], [doc2.id, doc3.id, doc4.id])
+
+        response = self.client.get("/api/documents/?title_content=X")
+        self.assertEqual(response.status_code, 200)
+        results = response.data['results']
+        self.assertEqual(len(results), 0)
+
     def test_search_no_query(self):
         response = self.client.get("/api/search/")
         results = response.data['results']


### PR DESCRIPTION
Implements #664 

---

Basically, the PR adds a "Filter by: ASN" Option, through which you can search documents directly by the ASN:
![Screenshot 2021-03-08 at 16 34 08](https://user-images.githubusercontent.com/71837281/110342933-3faab300-802c-11eb-8161-3c537211f4a0.png)