### PR TITLE
Fixes for mobile logger cut off & logged in as

### DIFF
--- a/src-ui/src/app/components/app-frame/app-frame.component.html
+++ b/src-ui/src/app/components/app-frame/app-frame.component.html
@@ -31,7 +31,7 @@
       </button>
       <div ngbDropdownMenu class="dropdown-menu-right shadow mr-2" aria-labelledby="userDropdown">
         <div *ngIf="displayName" class="d-sm-none">
-          <p class="small mb-0 px-3" i18n>Logged in as {{displayName}}</p>
+          <p class="small mb-0 px-3 text-muted" i18n>Logged in as {{displayName}}</p>
           <div class="dropdown-divider"></div>
         </div>
         <a ngbDropdownItem class="nav-link" routerLink="settings" (click)="closeMenu()">

--- a/src-ui/src/app/components/manage/logs/logs.component.html
+++ b/src-ui/src/app/components/manage/logs/logs.component.html
@@ -14,5 +14,5 @@
 <div class="bg-dark p-3 mb-3 text-light text-monospace log-container">
   <p
     class="m-0 p-0 log-entry-{{getLogLevel(log)}}"
-    *ngFor="let log of logs" style="white-space: pre;">{{log}}</p>
+    *ngFor="let log of logs">{{log}}</p>
 </div>

--- a/src-ui/src/app/components/manage/logs/logs.component.scss
+++ b/src-ui/src/app/components/manage/logs/logs.component.scss
@@ -16,9 +16,11 @@
 }
 
 .log-container {
-
-  overflow: scroll;
-
+  overflow-y: scroll;
   height: calc(100vh - 190px);
   top: 70px;
+
+  p {
+    white-space: pre-wrap;
+  }
 }


### PR DESCRIPTION
This small PR fixes two small css-ish bugs I noticed (screenshots below for reference):

- "Logged in as" is not visible in dark mode
- Logger is cut off on narrow screens

<img width="444" alt="Screen Shot 2021-03-11 at 4 06 28 PM" src="https://user-images.githubusercontent.com/4887959/110871912-200dc780-8284-11eb-930b-b582d6e489d0.png">
<img width="444" alt="Screenshot 2021-03-11 at 1 16 40 PM" src="https://user-images.githubusercontent.com/4887959/110871916-21d78b00-8284-11eb-9e9c-b2e2f2d17f8e.jpg">
