### PR TITLE
Fix additional card info icons sometimes cut off in certain browsers

### DIFF
--- a/src-ui/src/app/components/document-list/document-card-large/document-card-large.component.scss
+++ b/src-ui/src/app/components/document-list/document-card-large/document-card-large.component.scss
@@ -51,8 +51,9 @@
   }
 
   .metadata-icon {
-    width: 0.8rem;
-    height: 0.8rem;
+    width: 1.0rem;
+    height: 1.0rem;
+    padding: 0.05rem;
   }
 
   .search-score {

--- a/src-ui/src/app/components/document-list/document-card-large/document-card-large.component.scss
+++ b/src-ui/src/app/components/document-list/document-card-large/document-card-large.component.scss
@@ -51,8 +51,8 @@
   }
 
   .metadata-icon {
-    width: 1.0rem;
-    height: 1.0rem;
+    width: 0.9rem;
+    height: 0.9rem;
     padding: 0.05rem;
   }
 

--- a/src-ui/src/app/components/document-list/document-card-small/document-card-small.component.scss
+++ b/src-ui/src/app/components/document-list/document-card-small/document-card-small.component.scss
@@ -53,8 +53,8 @@
   }
 
   .metadata-icon {
-    width: 1.0rem;
-    height: 1.0rem;
+    width: 0.9rem;
+    height: 0.9rem;
     padding: 0.05rem;
   }
 }

--- a/src-ui/src/app/components/document-list/document-card-small/document-card-small.component.scss
+++ b/src-ui/src/app/components/document-list/document-card-small/document-card-small.component.scss
@@ -53,8 +53,9 @@
   }
 
   .metadata-icon {
-    width: 0.8rem;
-    height: 0.8rem;
+    width: 1.0rem;
+    height: 1.0rem;
+    padding: 0.05rem;
   }
 }
 


### PR DESCRIPTION
Not sure why I wasnt seeing this before but in Safari (not in Chrome at least on my machine) the icons are sometimes cut off. Solution is just a tiny bit of padding with css. Screenshot attached for reference.

<img width="932" alt="Screen Shot 2021-03-14 at 9 29 44 AM" src="https://user-images.githubusercontent.com/4887959/111076188-8b37e380-84a8-11eb-8295-4a5a95e1ed04.png">
