### PR TITLE
Fix extra scrollbar on log container, auto scroll logs to bottom

### DIFF
--- a/src-ui/src/app/components/manage/logs/logs.component.html
+++ b/src-ui/src/app/components/manage/logs/logs.component.html
@@ -11,7 +11,7 @@
 
 <div [ngbNavOutlet]="nav" class="mt-2"></div>
 
-<div class="bg-dark p-3 text-light text-monospace log-container">
+<div class="bg-dark p-3 text-light text-monospace log-container" #logContainer>
   <p
     class="m-0 p-0 log-entry-{{getLogLevel(log)}}"
     *ngFor="let log of logs">{{log}}</p>

--- a/src-ui/src/app/components/manage/logs/logs.component.html
+++ b/src-ui/src/app/components/manage/logs/logs.component.html
@@ -14,5 +14,5 @@
 <div class="bg-dark p-3 text-light text-monospace log-container">
   <p
     class="m-0 p-0 log-entry-{{getLogLevel(log)}}"
-    *ngFor="let log of logs">{{log}}</p>
+    *ngFor="let log of logs.reverse()">{{log}}</p>
 </div>

--- a/src-ui/src/app/components/manage/logs/logs.component.html
+++ b/src-ui/src/app/components/manage/logs/logs.component.html
@@ -14,5 +14,5 @@
 <div class="bg-dark p-3 text-light text-monospace log-container">
   <p
     class="m-0 p-0 log-entry-{{getLogLevel(log)}}"
-    *ngFor="let log of logs.reverse()">{{log}}</p>
+    *ngFor="let log of logs.slice().reverse()">{{log}}</p>
 </div>

--- a/src-ui/src/app/components/manage/logs/logs.component.html
+++ b/src-ui/src/app/components/manage/logs/logs.component.html
@@ -11,7 +11,7 @@
 
 <div [ngbNavOutlet]="nav" class="mt-2"></div>
 
-<div class="bg-dark p-3 mb-3 text-light text-monospace log-container">
+<div class="bg-dark p-3 text-light text-monospace log-container">
   <p
     class="m-0 p-0 log-entry-{{getLogLevel(log)}}"
     *ngFor="let log of logs">{{log}}</p>

--- a/src-ui/src/app/components/manage/logs/logs.component.html
+++ b/src-ui/src/app/components/manage/logs/logs.component.html
@@ -14,5 +14,5 @@
 <div class="bg-dark p-3 text-light text-monospace log-container">
   <p
     class="m-0 p-0 log-entry-{{getLogLevel(log)}}"
-    *ngFor="let log of logs.slice().reverse()">{{log}}</p>
+    *ngFor="let log of logs.reverse()">{{log}}</p>
 </div>

--- a/src-ui/src/app/components/manage/logs/logs.component.html
+++ b/src-ui/src/app/components/manage/logs/logs.component.html
@@ -14,5 +14,5 @@
 <div class="bg-dark p-3 text-light text-monospace log-container">
   <p
     class="m-0 p-0 log-entry-{{getLogLevel(log)}}"
-    *ngFor="let log of logs.reverse()">{{log}}</p>
+    *ngFor="let log of logs">{{log}}</p>
 </div>

--- a/src-ui/src/app/components/manage/logs/logs.component.scss
+++ b/src-ui/src/app/components/manage/logs/logs.component.scss
@@ -17,7 +17,7 @@
 
 .log-container {
   overflow-y: scroll;
-  height: calc(100vh - 190px);
+  height: calc(100vh - 200px);
   top: 70px;
 
   p {

--- a/src-ui/src/app/components/manage/logs/logs.component.ts
+++ b/src-ui/src/app/components/manage/logs/logs.component.ts
@@ -35,7 +35,6 @@ export class LogsComponent implements OnInit, AfterViewChecked {
   reloadLogs() {
     this.logService.get(this.activeLog).subscribe(result => {
       this.logs = result
-      this.scrollToBottom()
     }, error => {
       this.logs = []
     })

--- a/src-ui/src/app/components/manage/logs/logs.component.ts
+++ b/src-ui/src/app/components/manage/logs/logs.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, AfterViewChecked, ViewChild } from '@angular/core';
+import { Component, ElementRef, OnInit, AfterViewChecked, ViewChild } from '@angular/core';
 import { LogService } from 'src/app/services/rest/log.service';
 
 @Component({
@@ -6,7 +6,7 @@ import { LogService } from 'src/app/services/rest/log.service';
   templateUrl: './logs.component.html',
   styleUrls: ['./logs.component.scss']
 })
-export class LogsComponent implements AfterViewChecked {
+export class LogsComponent implements OnInit, AfterViewChecked {
 
   constructor(private logService: LogService) { }
 

--- a/src-ui/src/app/components/manage/logs/logs.component.ts
+++ b/src-ui/src/app/components/manage/logs/logs.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
+import { Component, ElementRef, AfterViewChecked, ViewChild } from '@angular/core';
 import { LogService } from 'src/app/services/rest/log.service';
 
 @Component({
@@ -6,7 +6,7 @@ import { LogService } from 'src/app/services/rest/log.service';
   templateUrl: './logs.component.html',
   styleUrls: ['./logs.component.scss']
 })
-export class LogsComponent implements OnInit {
+export class LogsComponent implements AfterViewChecked {
 
   constructor(private logService: LogService) { }
 
@@ -15,6 +15,8 @@ export class LogsComponent implements OnInit {
   logFiles: string[] = []
 
   activeLog: string
+
+  @ViewChild('logContainer') logContainer: ElementRef
 
   ngOnInit(): void {
     this.logService.list().subscribe(result => {
@@ -26,9 +28,14 @@ export class LogsComponent implements OnInit {
     })
   }
 
+  ngAfterViewChecked() {
+    this.scrollToBottom();
+  }
+
   reloadLogs() {
     this.logService.get(this.activeLog).subscribe(result => {
       this.logs = result
+      this.scrollToBottom()
     }, error => {
       this.logs = []
     })
@@ -46,6 +53,14 @@ export class LogsComponent implements OnInit {
     } else {
       return 20
     }
+  }
+
+  scrollToBottom(): void {
+    this.logContainer?.nativeElement.scroll({
+      top: this.logContainer.nativeElement.scrollHeight,
+      left: 0,
+      behavior: 'auto'
+    });
   }
 
 }


### PR DESCRIPTION
This PR closes #774 and #775 , it:

- Fixes css that caused an extra scrollbar on the log container
- ~~Reverses the order of log output (newest first)~~
- Automatically scrolls logs to the bottom