### PR TITLE
Support passing current term from tag / document type / correspondent search field to 'create new' dialog

### DIFF
--- a/src-ui/src/app/components/common/input/select/select.component.html
+++ b/src-ui/src/app/components/common/input/select/select.component.html
@@ -1,28 +1,29 @@
 <div class="form-group paperless-input-select">
   <label [for]="inputId">{{title}}</label>
-  <div [class.input-group]="showPlusButton()">
-    <ng-select name="inputId" [(ngModel)]="value"
+  <div>
+    <ng-select *ngIf="allowCreateNew; else noAddTag" name="inputId" [(ngModel)]="value"
       [disabled]="disabled"
       [style.color]="textColor"
       [style.background]="backgroundColor"
       [clearable]="allowNull"
       [items]="items"
+      [addTag]="addItemRef"
       bindLabel="name"
       bindValue="id"
-      (change)="onChange(value)"
-      (search)="onSearch($event)"
-      (focus)="clearLastSearchTerm()"
-      (clear)="clearLastSearchTerm()"
-      (blur)="onBlur()">
+      (blur)="onTouched()">
     </ng-select>
-
-    <div *ngIf="showPlusButton()" class="input-group-append">
-      <button class="btn btn-outline-secondary" type="button" (click)="clickNew()">
-        <svg class="buttonicon" fill="currentColor">
-          <use xlink:href="assets/bootstrap-icons.svg#plus" />
-        </svg>
-      </button>
-    </div>
+    <ng-template #noAddTag>
+      <ng-select name="inputId" [(ngModel)]="value"
+        [disabled]="disabled"
+        [style.color]="textColor"
+        [style.background]="backgroundColor"
+        [clearable]="allowNull"
+        [items]="items"
+        bindLabel="name"
+        bindValue="id"
+        (blur)="onTouched()">
+      </ng-select>
+    </ng-template>
   </div>
   <small *ngIf="hint" class="form-text text-muted">{{hint}}</small>
   <small *ngIf="getSuggestions().length > 0">

--- a/src-ui/src/app/components/common/input/select/select.component.html
+++ b/src-ui/src/app/components/common/input/select/select.component.html
@@ -11,7 +11,8 @@
       bindValue="id"
       (change)="onChange(value)"
       (search)="onSearch($event)"
-      (focus)="onFocus()"
+      (focus)="clearLastSearchTerm()"
+      (clear)="clearLastSearchTerm()"
       (blur)="onBlur()">
     </ng-select>
 

--- a/src-ui/src/app/components/common/input/select/select.component.html
+++ b/src-ui/src/app/components/common/input/select/select.component.html
@@ -10,11 +10,12 @@
       bindLabel="name"
       bindValue="id"
       (change)="onChange(value)"
-      (blur)="onTouched()">
+      (search)="onSearch($event)"
+      (focus)="onFocus()">
     </ng-select>
 
     <div *ngIf="showPlusButton()" class="input-group-append">
-      <button class="btn btn-outline-secondary" type="button" (click)="createNew.emit()">
+      <button class="btn btn-outline-secondary" type="button" (click)="clickNew()">
         <svg class="buttonicon" fill="currentColor">
           <use xlink:href="assets/bootstrap-icons.svg#plus" />
         </svg>
@@ -27,7 +28,7 @@
     <ng-container *ngFor="let s of getSuggestions()">
       <a (click)="value = s.id; onChange(value)" [routerLink]="">{{s.name}}</a>&nbsp;
     </ng-container>
-    
-    
+
+
   </small>
 </div>

--- a/src-ui/src/app/components/common/input/select/select.component.html
+++ b/src-ui/src/app/components/common/input/select/select.component.html
@@ -1,13 +1,13 @@
 <div class="form-group paperless-input-select">
   <label [for]="inputId">{{title}}</label>
     <div [class.input-group]="allowCreateNew">
-      <ng-select *ngIf="allowCreateNew; else noAddTag" name="inputId" [(ngModel)]="value"
+      <ng-select name="inputId" [(ngModel)]="value"
         [disabled]="disabled"
         [style.color]="textColor"
         [style.background]="backgroundColor"
         [clearable]="allowNull"
         [items]="items"
-        [addTag]="addItemRef"
+        [addTag]="allowCreateNew && addItemRef"
         bindLabel="name"
         bindValue="id"
         (change)="onChange(value)"
@@ -16,22 +16,6 @@
         (clear)="clearLastSearchTerm()"
         (blur)="onBlur()">
       </ng-select>
-      <ng-template #noAddTag>
-        <ng-select name="inputId" [(ngModel)]="value"
-          [disabled]="disabled"
-          [style.color]="textColor"
-          [style.background]="backgroundColor"
-          [clearable]="allowNull"
-          [items]="items"
-          bindLabel="name"
-          bindValue="id"
-          (change)="onChange(value)"
-          (search)="onSearch($event)"
-          (focus)="clearLastSearchTerm()"
-          (clear)="clearLastSearchTerm()"
-          (blur)="onBlur()">
-        </ng-select>
-      </ng-template>
       <div *ngIf="allowCreateNew" class="input-group-append">
         <button class="btn btn-outline-secondary" type="button" (click)="addItem()">
           <svg class="buttonicon" fill="currentColor">

--- a/src-ui/src/app/components/common/input/select/select.component.html
+++ b/src-ui/src/app/components/common/input/select/select.component.html
@@ -11,7 +11,8 @@
       bindValue="id"
       (change)="onChange(value)"
       (search)="onSearch($event)"
-      (focus)="onFocus()">
+      (focus)="onFocus()"
+      (blur)="onBlur()">
     </ng-select>
 
     <div *ngIf="showPlusButton()" class="input-group-append">

--- a/src-ui/src/app/components/common/input/select/select.component.html
+++ b/src-ui/src/app/components/common/input/select/select.component.html
@@ -1,30 +1,45 @@
 <div class="form-group paperless-input-select">
   <label [for]="inputId">{{title}}</label>
-  <div>
-    <ng-select *ngIf="allowCreateNew; else noAddTag" name="inputId" [(ngModel)]="value"
-      [disabled]="disabled"
-      [style.color]="textColor"
-      [style.background]="backgroundColor"
-      [clearable]="allowNull"
-      [items]="items"
-      [addTag]="addItemRef"
-      bindLabel="name"
-      bindValue="id"
-      (blur)="onTouched()">
-    </ng-select>
-    <ng-template #noAddTag>
-      <ng-select name="inputId" [(ngModel)]="value"
+    <div [class.input-group]="allowCreateNew">
+      <ng-select *ngIf="allowCreateNew; else noAddTag" name="inputId" [(ngModel)]="value"
         [disabled]="disabled"
         [style.color]="textColor"
         [style.background]="backgroundColor"
         [clearable]="allowNull"
         [items]="items"
+        [addTag]="addItemRef"
         bindLabel="name"
         bindValue="id"
-        (blur)="onTouched()">
+        (change)="onChange(value)"
+        (search)="onSearch($event)"
+        (focus)="clearLastSearchTerm()"
+        (clear)="clearLastSearchTerm()"
+        (blur)="onBlur()">
       </ng-select>
-    </ng-template>
-  </div>
+      <ng-template #noAddTag>
+        <ng-select name="inputId" [(ngModel)]="value"
+          [disabled]="disabled"
+          [style.color]="textColor"
+          [style.background]="backgroundColor"
+          [clearable]="allowNull"
+          [items]="items"
+          bindLabel="name"
+          bindValue="id"
+          (change)="onChange(value)"
+          (search)="onSearch($event)"
+          (focus)="clearLastSearchTerm()"
+          (clear)="clearLastSearchTerm()"
+          (blur)="onBlur()">
+        </ng-select>
+      </ng-template>
+      <div *ngIf="allowCreateNew" class="input-group-append">
+        <button class="btn btn-outline-secondary" type="button" (click)="addItem()">
+          <svg class="buttonicon" fill="currentColor">
+            <use xlink:href="assets/bootstrap-icons.svg#plus" />
+          </svg>
+        </button>
+      </div>
+    </div>
   <small *ngIf="hint" class="form-text text-muted">{{hint}}</small>
   <small *ngIf="getSuggestions().length > 0">
     <span i18n>Suggestions:</span>&nbsp;

--- a/src-ui/src/app/components/common/input/select/select.component.ts
+++ b/src-ui/src/app/components/common/input/select/select.component.ts
@@ -39,6 +39,8 @@ export class SelectComponent extends AbstractInputComponent<number> {
 
   public addItemRef: (name) => void
 
+  private _lastSearchTerm: string
+
   get allowCreateNew(): boolean {
     return this.createNew.observers.length > 0
   }
@@ -52,7 +54,28 @@ export class SelectComponent extends AbstractInputComponent<number> {
   }
 
   addItem(name: string) {
-    this.createNew.next(name)
+    if (name) this.createNew.next(name)
+    else this.createNew.next(this._lastSearchTerm)
+    this.clearLastSearchTerm()
+  }
+
+  clickNew() {
+    this.createNew.next(this._lastSearchTerm)
+    this.clearLastSearchTerm()
+  }
+
+  clearLastSearchTerm() {
+    this._lastSearchTerm = null
+  }
+
+  onSearch($event) {
+    this._lastSearchTerm = $event.term
+  }
+
+  onBlur() {
+    setTimeout(() => {
+      this.clearLastSearchTerm()
+    }, 3000);
   }
 
 }

--- a/src-ui/src/app/components/common/input/select/select.component.ts
+++ b/src-ui/src/app/components/common/input/select/select.component.ts
@@ -16,6 +16,7 @@ export class SelectComponent extends AbstractInputComponent<number> {
 
   constructor() {
     super()
+    this.addItemRef = this.addItem.bind(this)
    }
 
   @Input()
@@ -36,9 +37,9 @@ export class SelectComponent extends AbstractInputComponent<number> {
   @Output()
   createNew = new EventEmitter<string>()
 
-  private _lastSearchTerm: string
+  public addItemRef: (name) => void
 
-  showPlusButton(): boolean {
+  get allowCreateNew(): boolean {
     return this.createNew.observers.length > 0
   }
 
@@ -50,23 +51,8 @@ export class SelectComponent extends AbstractInputComponent<number> {
     }
   }
 
-  clickNew() {
-    this.createNew.next(this._lastSearchTerm)
-    this.clearLastSearchTerm()
-  }
-
-  clearLastSearchTerm() {
-    this._lastSearchTerm = null
-  }
-
-  onSearch($event) {
-    this._lastSearchTerm = $event.term
-  }
-
-  onBlur() {
-    setTimeout(() => {
-      this.clearLastSearchTerm()
-    }, 3000);
+  addItem(name: string) {
+    this.createNew.next(name)
   }
 
 }

--- a/src-ui/src/app/components/common/input/select/select.component.ts
+++ b/src-ui/src/app/components/common/input/select/select.component.ts
@@ -63,4 +63,10 @@ export class SelectComponent extends AbstractInputComponent<number> {
     this._lastSearchTerm = $event.term
   }
 
+  onBlur() {
+    setTimeout(() => {
+      this._lastSearchTerm = null
+    }, 3000);
+  }
+
 }

--- a/src-ui/src/app/components/common/input/select/select.component.ts
+++ b/src-ui/src/app/components/common/input/select/select.component.ts
@@ -52,10 +52,10 @@ export class SelectComponent extends AbstractInputComponent<number> {
 
   clickNew() {
     this.createNew.next(this._lastSearchTerm)
-    this._lastSearchTerm = null
+    this.clearLastSearchTerm()
   }
 
-  onFocus() {
+  clearLastSearchTerm() {
     this._lastSearchTerm = null
   }
 
@@ -65,7 +65,7 @@ export class SelectComponent extends AbstractInputComponent<number> {
 
   onBlur() {
     setTimeout(() => {
-      this._lastSearchTerm = null
+      this.clearLastSearchTerm()
     }, 3000);
   }
 

--- a/src-ui/src/app/components/common/input/select/select.component.ts
+++ b/src-ui/src/app/components/common/input/select/select.component.ts
@@ -34,7 +34,9 @@ export class SelectComponent extends AbstractInputComponent<number> {
   suggestions: number[]
 
   @Output()
-  createNew = new EventEmitter()
+  createNew = new EventEmitter<string>()
+
+  private _lastSearchTerm: string
 
   showPlusButton(): boolean {
     return this.createNew.observers.length > 0
@@ -46,6 +48,19 @@ export class SelectComponent extends AbstractInputComponent<number> {
     } else {
       return []
     }
+  }
+
+  clickNew() {
+    this.createNew.next(this._lastSearchTerm)
+    this._lastSearchTerm = null
+  }
+
+  onFocus() {
+    this._lastSearchTerm = null
+  }
+
+  onSearch($event) {
+    this._lastSearchTerm = $event.term
   }
 
 }

--- a/src-ui/src/app/components/common/input/tags/tags.component.html
+++ b/src-ui/src/app/components/common/input/tags/tags.component.html
@@ -1,17 +1,16 @@
 <div class="form-group paperless-input-select paperless-input-tags">
   <label for="tags" i18n>Tags</label>
 
-  <div class="input-group flex-nowrap">
+  <div class="flex-nowrap">
     <ng-select name="tags" [items]="tags" bindLabel="name" bindValue="id" [(ngModel)]="value"
       [multiple]="true"
       [closeOnSelect]="false"
       [clearSearchOnAdd]="true"
       [hideSelected]="true"
+      [addTag]="createTagRef"
+      addTagText="Add tag"
       (change)="onChange(value)"
-      (search)="onSearch($event)"
-      (focus)="clearLastSearchTerm()"
-      (clear)="clearLastSearchTerm()"
-      (blur)="onBlur()">
+      (blur)="onTouched()">
 
       <ng-template ng-label-tmp let-item="item">
         <span class="tag-wrap tag-wrap-delete" (click)="removeTag(item.id)">
@@ -27,14 +26,6 @@
         </div>
       </ng-template>
     </ng-select>
-
-    <div class="input-group-append">
-      <button class="btn btn-outline-secondary" type="button" (click)="createTag()">
-        <svg class="buttonicon" fill="currentColor">
-          <use xlink:href="assets/bootstrap-icons.svg#plus" />
-        </svg>
-      </button>
-    </div>
   </div>
   <small class="form-text text-muted" *ngIf="hint">{{hint}}</small>
   <small *ngIf="getSuggestions().length > 0">

--- a/src-ui/src/app/components/common/input/tags/tags.component.html
+++ b/src-ui/src/app/components/common/input/tags/tags.component.html
@@ -9,7 +9,8 @@
       [hideSelected]="true"
       (change)="onChange(value)"
       (search)="onSearch($event)"
-      (focus)="onFocus()"
+      (focus)="clearLastSearchTerm()"
+      (clear)="clearLastSearchTerm()"
       (blur)="onBlur()">
 
       <ng-template ng-label-tmp let-item="item">

--- a/src-ui/src/app/components/common/input/tags/tags.component.html
+++ b/src-ui/src/app/components/common/input/tags/tags.component.html
@@ -1,7 +1,7 @@
 <div class="form-group paperless-input-select paperless-input-tags">
   <label for="tags" i18n>Tags</label>
 
-  <div class="flex-nowrap">
+  <div class="input-group flex-nowrap">
     <ng-select name="tags" [items]="tags" bindLabel="name" bindValue="id" [(ngModel)]="value"
       [multiple]="true"
       [closeOnSelect]="false"
@@ -10,7 +10,10 @@
       [addTag]="createTagRef"
       addTagText="Add tag"
       (change)="onChange(value)"
-      (blur)="onTouched()">
+      (search)="onSearch($event)"
+      (focus)="clearLastSearchTerm()"
+      (clear)="clearLastSearchTerm()"
+      (blur)="onBlur()">
 
       <ng-template ng-label-tmp let-item="item">
         <span class="tag-wrap tag-wrap-delete" (click)="removeTag(item.id)">
@@ -26,6 +29,14 @@
         </div>
       </ng-template>
     </ng-select>
+
+    <div class="input-group-append">
+      <button class="btn btn-outline-secondary" type="button" (click)="createTag()">
+        <svg class="buttonicon" fill="currentColor">
+          <use xlink:href="assets/bootstrap-icons.svg#plus" />
+        </svg>
+      </button>
+    </div>
   </div>
   <small class="form-text text-muted" *ngIf="hint">{{hint}}</small>
   <small *ngIf="getSuggestions().length > 0">

--- a/src-ui/src/app/components/common/input/tags/tags.component.html
+++ b/src-ui/src/app/components/common/input/tags/tags.component.html
@@ -8,7 +8,8 @@
       [clearSearchOnAdd]="true"
       [hideSelected]="true"
       (change)="onChange(value)"
-      (blur)="onTouched()">
+      (search)="onSearch($event)"
+      (focus)="onFocus()">
 
       <ng-template ng-label-tmp let-item="item">
         <span class="tag-wrap tag-wrap-delete" (click)="removeTag(item.id)">
@@ -39,8 +40,8 @@
     <ng-container *ngFor="let tag of getSuggestions()">
       <a (click)="addTag(tag.id)" [routerLink]="">{{tag.name}}</a>&nbsp;
     </ng-container>
-    
-    
+
+
   </small>
 
 </div>

--- a/src-ui/src/app/components/common/input/tags/tags.component.html
+++ b/src-ui/src/app/components/common/input/tags/tags.component.html
@@ -9,7 +9,8 @@
       [hideSelected]="true"
       (change)="onChange(value)"
       (search)="onSearch($event)"
-      (focus)="onFocus()">
+      (focus)="onFocus()"
+      (blur)="onBlur()">
 
       <ng-template ng-label-tmp let-item="item">
         <span class="tag-wrap tag-wrap-delete" (click)="removeTag(item.id)">

--- a/src-ui/src/app/components/common/input/tags/tags.component.ts
+++ b/src-ui/src/app/components/common/input/tags/tags.component.ts
@@ -105,7 +105,7 @@ export class TagsComponent implements OnInit, ControlValueAccessor {
     this.onChange(this.value)
   }
 
-  onFocus() {
+  clearLastSearchTerm() {
     this._lastSearchTerm = null
   }
 
@@ -115,7 +115,7 @@ export class TagsComponent implements OnInit, ControlValueAccessor {
 
   onBlur() {
     setTimeout(() => {
-      this._lastSearchTerm = null
+      this.clearLastSearchTerm()
     }, 3000);
   }
 

--- a/src-ui/src/app/components/common/input/tags/tags.component.ts
+++ b/src-ui/src/app/components/common/input/tags/tags.component.ts
@@ -113,4 +113,10 @@ export class TagsComponent implements OnInit, ControlValueAccessor {
     this._lastSearchTerm = $event.term
   }
 
+  onBlur() {
+    setTimeout(() => {
+      this._lastSearchTerm = null
+    }, 3000);
+  }
+
 }

--- a/src-ui/src/app/components/common/input/tags/tags.component.ts
+++ b/src-ui/src/app/components/common/input/tags/tags.component.ts
@@ -56,8 +56,10 @@ export class TagsComponent implements OnInit, ControlValueAccessor {
   value: number[]
 
   tags: PaperlessTag[]
-  
+
   public createTagRef: (name) => void
+
+  private _lastSearchTerm: string
 
   getTag(id) {
     if (this.tags) {
@@ -81,6 +83,7 @@ export class TagsComponent implements OnInit, ControlValueAccessor {
     var modal = this.modalService.open(TagEditDialogComponent, {backdrop: 'static'})
     modal.componentInstance.dialogMode = 'create'
     if (name) modal.componentInstance.object = { name: name }
+    else if (this._lastSearchTerm) modal.componentInstance.object = { name: this._lastSearchTerm }
     modal.componentInstance.success.subscribe(newTag => {
       this.tagService.listAll().subscribe(tags => {
         this.tags = tags.results
@@ -101,6 +104,20 @@ export class TagsComponent implements OnInit, ControlValueAccessor {
   addTag(id) {
     this.value = [...this.value, id]
     this.onChange(this.value)
+  }
+
+  clearLastSearchTerm() {
+    this._lastSearchTerm = null
+  }
+
+  onSearch($event) {
+    this._lastSearchTerm = $event.term
+  }
+
+  onBlur() {
+    setTimeout(() => {
+      this.clearLastSearchTerm()
+    }, 3000);
   }
 
 }

--- a/src-ui/src/app/components/common/input/tags/tags.component.ts
+++ b/src-ui/src/app/components/common/input/tags/tags.component.ts
@@ -87,9 +87,6 @@ export class TagsComponent implements OnInit, ControlValueAccessor {
         this.onChange(this.value)
       })
     })
-    modal.result.then(() => {
-      this._lastSearchTerm = null
-    })
   }
 
   getSuggestions() {

--- a/src-ui/src/app/components/common/input/tags/tags.component.ts
+++ b/src-ui/src/app/components/common/input/tags/tags.component.ts
@@ -17,8 +17,9 @@ import { TagService } from 'src/app/services/rest/tag.service';
 })
 export class TagsComponent implements OnInit, ControlValueAccessor {
 
-  constructor(private tagService: TagService, private modalService: NgbModal) { }
-
+  constructor(private tagService: TagService, private modalService: NgbModal) {
+    this.createTagRef = this.createTag.bind(this)
+  }
 
   onChange = (newValue: number[]) => {};
 
@@ -55,8 +56,8 @@ export class TagsComponent implements OnInit, ControlValueAccessor {
   value: number[]
 
   tags: PaperlessTag[]
-
-  private _lastSearchTerm: string
+  
+  public createTagRef: (name) => void
 
   getTag(id) {
     if (this.tags) {
@@ -76,10 +77,10 @@ export class TagsComponent implements OnInit, ControlValueAccessor {
     }
   }
 
-  createTag() {
+  createTag(name: string = null) {
     var modal = this.modalService.open(TagEditDialogComponent, {backdrop: 'static'})
     modal.componentInstance.dialogMode = 'create'
-    if (this._lastSearchTerm) modal.componentInstance.object = { name: this._lastSearchTerm }
+    if (name) modal.componentInstance.object = { name: name }
     modal.componentInstance.success.subscribe(newTag => {
       this.tagService.listAll().subscribe(tags => {
         this.tags = tags.results
@@ -100,20 +101,6 @@ export class TagsComponent implements OnInit, ControlValueAccessor {
   addTag(id) {
     this.value = [...this.value, id]
     this.onChange(this.value)
-  }
-
-  clearLastSearchTerm() {
-    this._lastSearchTerm = null
-  }
-
-  onSearch($event) {
-    this._lastSearchTerm = $event.term
-  }
-
-  onBlur() {
-    setTimeout(() => {
-      this.clearLastSearchTerm()
-    }, 3000);
   }
 
 }

--- a/src-ui/src/app/components/common/input/tags/tags.component.ts
+++ b/src-ui/src/app/components/common/input/tags/tags.component.ts
@@ -56,6 +56,8 @@ export class TagsComponent implements OnInit, ControlValueAccessor {
 
   tags: PaperlessTag[]
 
+  private _lastSearchTerm: string
+
   getTag(id) {
     if (this.tags) {
       return this.tags.find(tag => tag.id == id)
@@ -77,12 +79,16 @@ export class TagsComponent implements OnInit, ControlValueAccessor {
   createTag() {
     var modal = this.modalService.open(TagEditDialogComponent, {backdrop: 'static'})
     modal.componentInstance.dialogMode = 'create'
+    if (this._lastSearchTerm) modal.componentInstance.object = { name: this._lastSearchTerm }
     modal.componentInstance.success.subscribe(newTag => {
       this.tagService.listAll().subscribe(tags => {
         this.tags = tags.results
         this.value = [...this.value, newTag.id]
         this.onChange(this.value)
       })
+    })
+    modal.result.then(() => {
+      this._lastSearchTerm = null
     })
   }
 
@@ -97,6 +103,14 @@ export class TagsComponent implements OnInit, ControlValueAccessor {
   addTag(id) {
     this.value = [...this.value, id]
     this.onChange(this.value)
+  }
+
+  onFocus() {
+    this._lastSearchTerm = null
+  }
+
+  onSearch($event) {
+    this._lastSearchTerm = $event.term
   }
 
 }

--- a/src-ui/src/app/components/document-detail/document-detail.component.html
+++ b/src-ui/src/app/components/document-detail/document-detail.component.html
@@ -60,9 +60,9 @@
                         <app-input-number i18n-title title="Archive serial number" [error]="error?.archive_serial_number" formControlName='archive_serial_number'></app-input-number>
                         <app-input-date i18n-title title="Date created" formControlName="created" [error]="error?.created"></app-input-date>
                         <app-input-select [items]="correspondents" i18n-title title="Correspondent" formControlName="correspondent" [allowNull]="true"
-                            (createNew)="createCorrespondent()" [suggestions]="suggestions?.correspondents"></app-input-select>
+                            (createNew)="createCorrespondent($event)" [suggestions]="suggestions?.correspondents"></app-input-select>
                         <app-input-select [items]="documentTypes" i18n-title title="Document type" formControlName="document_type" [allowNull]="true"
-                            (createNew)="createDocumentType()" [suggestions]="suggestions?.document_types"></app-input-select>
+                            (createNew)="createDocumentType($event)" [suggestions]="suggestions?.document_types"></app-input-select>
                         <app-input-tags formControlName="tags" [suggestions]="suggestions?.tags"></app-input-tags>
 
                     </ng-template>

--- a/src-ui/src/app/components/document-detail/document-detail.component.ts
+++ b/src-ui/src/app/components/document-detail/document-detail.component.ts
@@ -127,9 +127,10 @@ export class DocumentDetailComponent implements OnInit {
     this.documentForm.patchValue(doc)
   }
 
-  createDocumentType() {
+  createDocumentType(newName: string) {
     var modal = this.modalService.open(DocumentTypeEditDialogComponent, {backdrop: 'static'})
     modal.componentInstance.dialogMode = 'create'
+    if (newName) modal.componentInstance.object = { name: newName }
     modal.componentInstance.success.subscribe(newDocumentType => {
       this.documentTypeService.listAll().subscribe(documentTypes => {
         this.documentTypes = documentTypes.results
@@ -138,9 +139,10 @@ export class DocumentDetailComponent implements OnInit {
     })
   }
 
-  createCorrespondent() {
+  createCorrespondent(newName: string) {
     var modal = this.modalService.open(CorrespondentEditDialogComponent, {backdrop: 'static'})
     modal.componentInstance.dialogMode = 'create'
+    if (newName) modal.componentInstance.object = { name: newName }
     modal.componentInstance.success.subscribe(newCorrespondent => {
       this.correspondentService.listAll().subscribe(correspondents => {
         this.correspondents = correspondents.results

--- a/src-ui/src/styles.scss
+++ b/src-ui/src/styles.scss
@@ -77,8 +77,6 @@ body {
 
     .ng-select-container {
       height: 100%;
-      border-top-right-radius: 0;
-      border-bottom-right-radius: 0;
 
       .ng-value-container .ng-input {
         top: 10px;

--- a/src-ui/src/styles.scss
+++ b/src-ui/src/styles.scss
@@ -77,6 +77,8 @@ body {
 
     .ng-select-container {
       height: 100%;
+      border-top-right-radius: 0;
+      border-bottom-right-radius: 0;
 
       .ng-value-container .ng-input {
         top: 10px;


### PR DESCRIPTION
This PR addresses #817 , it implements passing the current search term to a "Create New" dialog for tags, document types & correspondents on the document edit page.

~~@jonaswinkler Ha, as usual, this was slightly more complicated than I thought but I think this is a clean solution. Because the native `ng-select` component immediately clears search terms on `blur`, the value needs to be stored with `search` events. Then on blur a timeout is set for 3 seconds to allow passing to the dialog if that is the next action, otherwise its cleared. The stored term is also cleared appropriately with pressing clear button, re-entering the field and when the new dialog event fires. Basically this is to prevent the search term hanging around long after a user actually interacted with the field. Let me know if you have any issues with this.~~

Edit: this now uses `addTag` function of ng-select see https://ng-select.github.io/ng-select#/tags


https://user-images.githubusercontent.com/4887959/113484859-67d8d680-945f-11eb-82ec-2e917152e97d.mov
