### PR TITLE
Fix alignment of card info on large cards

### DIFF
--- a/src-ui/src/app/components/document-list/document-card-large/document-card-large.component.html
+++ b/src-ui/src/app/components/document-list/document-card-large/document-card-large.component.html
@@ -82,7 +82,8 @@
               </svg>
               <small>{{document.created | customDate:'mediumDate'}}</small>
             </div>
-            <div *ngIf="document.__search_hit__" class="list-group-item bg-light text-dark border-0 d-flex search-score">
+
+            <div *ngIf="document.__search_hit__" class="list-group-item bg-light text-dark border-0 d-flex p-0 pl-4 search-score">
               <small class="text-muted" i18n>Score:</small>
               <ngb-progressbar [type]="searchScoreClass" [value]="document.__search_hit__.score" class="search-score-bar mx-2 mt-1" [max]="1"></ngb-progressbar>
             </div>


### PR DESCRIPTION
This miniscule PR fixes a minor layout bug after merging the search UI (which, btw, is totally awesome). Screenshot below.

One extra note: I noticed you swapped the L-to-R order of the search score & info icons, I kinda think it makes more sense to have score on the left so that the icons are always in the same spot, bottom right. If you agree I can swap that too but obviously NBD if not.

<img width="585" alt="Screen Shot 2021-04-06 at 2 11 00 PM" src="https://user-images.githubusercontent.com/4887959/113780324-eba2f500-96e3-11eb-806f-3e063df27b0c.png">
<img width="571" alt="Screen Shot 2021-04-06 at 2 24 25 PM" src="https://user-images.githubusercontent.com/4887959/113780330-ec3b8b80-96e3-11eb-9aa9-8e6ccb327760.png">
