### PR TITLE
Make paperless-ng able to run as a rootless container (support for podman)

### DIFF
--- a/Dockerfile.rootless
+++ b/Dockerfile.rootless
@@ -1,0 +1,101 @@
+FROM ubuntu:20.04 AS jbig2enc
+
+WORKDIR /usr/src/jbig2enc
+
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential automake libtool libleptonica-dev zlib1g-dev git ca-certificates
+
+RUN git clone https://github.com/agl/jbig2enc .
+RUN ./autogen.sh
+RUN ./configure && make
+
+FROM python:3.7-slim
+
+# Binary dependencies
+RUN echo "deb http://deb.debian.org/debian bullseye main" > /etc/apt/sources.list.d/bullseye.list \
+  && apt-get update \
+  && apt-get -y --no-install-recommends install \
+  	# Basic dependencies
+		curl \
+		gnupg \
+		imagemagick \
+		gettext \
+		sudo \
+		tzdata \
+		# fonts for text file thumbnail generation
+		fonts-liberation \
+		# for Numpy
+		libatlas-base-dev \
+		libxslt1-dev \
+		# thumbnail size reduction
+		optipng \
+		# Mime type detection
+		file \
+		libmagic-dev \
+		media-types \
+  	# OCRmyPDF dependencies
+		ghostscript \
+		icc-profiles-free \
+		liblept5 \
+		libxml2 \
+		pngquant \
+		qpdf \
+		tesseract-ocr \
+		tesseract-ocr-eng \
+		tesseract-ocr-deu \
+		tesseract-ocr-fra \
+		tesseract-ocr-ita \
+		tesseract-ocr-spa \
+		unpaper \
+		zlib1g \
+  && rm -rf /var/lib/apt/lists/*
+
+# copy jbig2enc
+COPY --from=jbig2enc /usr/src/jbig2enc/src/.libs/libjbig2enc* /usr/local/lib/
+COPY --from=jbig2enc /usr/src/jbig2enc/src/jbig2 /usr/local/bin/
+COPY --from=jbig2enc /usr/src/jbig2enc/src/*.h /usr/local/include/
+
+WORKDIR /usr/src/paperless/src/
+
+COPY requirements.txt ../
+
+# Python dependencies
+RUN apt-get update \
+  && apt-get -y --no-install-recommends install \
+		build-essential \
+		libpq-dev \
+		libqpdf-dev \
+	&& python3 -m pip install --upgrade --no-cache-dir supervisor \
+  && python3 -m pip install --no-cache-dir -r ../requirements.txt \
+	&& apt-get -y purge build-essential libqpdf-dev \
+	&& apt-get -y autoremove --purge \
+	&& rm -rf /var/lib/apt/lists/*
+
+# setup docker-specific things
+COPY docker/ ./docker/
+
+RUN cd docker \
+  && cp imagemagick-policy.xml /etc/ImageMagick-6/policy.xml \
+	&& mkdir /var/log/supervisord /var/run/supervisord \
+	&& cp supervisord-rootless.conf /etc/supervisord.conf \
+	&& cp docker-entrypoint.sh /sbin/docker-entrypoint.sh \
+	&& chmod 755 /sbin/docker-entrypoint.sh \
+	&& chmod +x install_management_commands.sh \
+	&& ./install_management_commands.sh \
+	&& cd .. \
+	&& rm docker -rf
+
+COPY gunicorn.conf.py ../
+
+# copy app
+COPY src/ ./
+
+# add users, setup scripts
+RUN python3 manage.py collectstatic --clear --no-input \
+	&& python3 manage.py compilemessages
+
+VOLUME ["/usr/src/paperless/data", "/usr/src/paperless/media", "/usr/src/paperless/consume", "/usr/src/paperless/export"]
+ENTRYPOINT ["/sbin/docker-entrypoint.sh"]
+EXPOSE 8000
+CMD ["/usr/local/bin/supervisord", "-c", "/etc/supervisord.conf"]
+
+LABEL maintainer="Jonas Winkler <dev@jpwinkler.de>"

--- a/docker/compose/docker-compose.env
+++ b/docker/compose/docker-compose.env
@@ -1,6 +1,7 @@
 # The UID and GID of the user used to run paperless in the container. Set this
 # to your UID and GID on the host so that you have write access to the
 # consumption directory.
+# Note: this setting is ignored when run as a rootless container (podman).
 #USERMAP_UID=1000
 #USERMAP_GID=1000
 
@@ -13,6 +14,9 @@
 # See https://packages.debian.org/search?keywords=tesseract-ocr-&searchon=names&suite=buster
 # for available languages.
 #PAPERLESS_OCR_LANGUAGES=tur ces
+
+# Run paperless as a rootless container (podman)
+#PAPERLESS_ROOTLESS=1
 
 ###############################################################################
 # Paperless-specific settings                                                 #

--- a/docker/supervisord-rootless.conf
+++ b/docker/supervisord-rootless.conf
@@ -1,0 +1,32 @@
+[supervisord]
+nodaemon=true               ; start in foreground if true; default false
+logfile=/var/log/supervisord/supervisord.log ; main log file; default $CWD/supervisord.log
+pidfile=/var/run/supervisord/supervisord.pid ; supervisord pidfile; default supervisord.pid
+logfile_maxbytes=50MB        ; max main logfile bytes b4 rotation; default 50MB
+logfile_backups=10           ; # of main logfile backups; 0 means none, default 10
+loglevel=info                ; log level; default info; others: debug,warn,trace
+user=root
+
+[program:gunicorn]
+command=gunicorn -c /usr/src/paperless/gunicorn.conf.py paperless.asgi:application
+
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:consumer]
+command=python3 manage.py document_consumer
+
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:scheduler]
+command=python3 manage.py qcluster
+
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0


### PR DESCRIPTION
When using `podman` instead of Docker, it is possible to run containers in a rootless mode, ie. containers are directly created by the user and not by `root` through the Docker daemon.

A key difference of rootless containers is that they run in a different user namespace, where the `root` user *inside* the container (uid 1) is transparently mapped to the user creating the container *outside* on the host, and other users inside the container get alternative user id in a different namespace than the host user namespace.

As a consequence, running paperless-ng webserver as `root` inside the rootless container is actually what we want: the paperless processes are then run by the user from the host point-of-view, and thus are able to read/write to the consume and export directories.

The current trick of forcing the paperless uid/gid to match the host user cannot work for rootless containers, as uid/gid are remapped.

This proposed patch adds an alternative Dockerfile for creating a rootless container image (mainly removal of paperless user and chown), and a new Docker compose environment variable PAPERLESS_ROOTLESS which runs the webserver container processes as `root` instead of `paperless`.