### PR TITLE
Add --no-progress-bar option to commands

### DIFF
--- a/src/documents/management/commands/document_archiver.py
+++ b/src/documents/management/commands/document_archiver.py
@@ -106,6 +106,12 @@ class Command(BaseCommand):
             help="Specify the ID of a document, and this command will only "
                  "run on this specific document."
         )
+        parser.add_argument(
+            "--no-progress-bar",
+            default=False,
+            action="store_true",
+            help="If set, the progress bar will not be shown"
+        )
 
     def handle(self, *args, **options):
 
@@ -140,7 +146,8 @@ class Command(BaseCommand):
                         handle_document,
                         document_ids
                     ),
-                    total=len(document_ids)
+                    total=len(document_ids),
+                    disable=options['no_progress_bar']
                 ))
         except KeyboardInterrupt:
             print("Aborting...")

--- a/src/documents/management/commands/document_index.py
+++ b/src/documents/management/commands/document_index.py
@@ -10,10 +10,16 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument("command", choices=['reindex', 'optimize'])
+        parser.add_argument(
+            "--no-progress-bar",
+            default=False,
+            action="store_true",
+            help="If set, the progress bar will not be shown"
+        )
 
     def handle(self, *args, **options):
         with transaction.atomic():
             if options['command'] == 'reindex':
-                index_reindex()
+                index_reindex(progress_bar_disable=options['no_progress_bar'])
             elif options['command'] == 'optimize':
                 index_optimize()

--- a/src/documents/management/commands/document_renamer.py
+++ b/src/documents/management/commands/document_renamer.py
@@ -13,9 +13,20 @@ class Command(BaseCommand):
         This will rename all documents to match the latest filename format.
     """.replace("    ", "")
 
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--no-progress-bar",
+            default=False,
+            action="store_true",
+            help="If set, the progress bar will not be shown"
+        )
+
     def handle(self, *args, **options):
 
         logging.getLogger().handlers[0].level = logging.ERROR
 
-        for document in tqdm.tqdm(Document.objects.all()):
+        for document in tqdm.tqdm(
+            Document.objects.all(),
+            disable=options['no_progress_bar']
+        ):
             post_save.send(Document, instance=document)

--- a/src/documents/management/commands/document_retagger.py
+++ b/src/documents/management/commands/document_retagger.py
@@ -57,6 +57,12 @@ class Command(BaseCommand):
                  "set correspondent, document and remove correspondents, types"
                  "and tags that do not match anymore due to changed rules."
         )
+        parser.add_argument(
+            "--no-progress-bar",
+            default=False,
+            action="store_true",
+            help="If set, the progress bar will not be shown"
+        )
 
     def handle(self, *args, **options):
 
@@ -68,7 +74,10 @@ class Command(BaseCommand):
 
         classifier = load_classifier()
 
-        for document in tqdm.tqdm(documents):
+        for document in tqdm.tqdm(
+            documents,
+            disable=options['no_progress_bar']
+        ):
 
             if options['correspondent']:
                 set_correspondent(

--- a/src/documents/management/commands/document_sanity_checker.py
+++ b/src/documents/management/commands/document_sanity_checker.py
@@ -8,8 +8,16 @@ class Command(BaseCommand):
         This command checks your document archive for issues.
     """.replace("    ", "")
 
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--no-progress-bar",
+            default=False,
+            action="store_true",
+            help="If set, the progress bar will not be shown"
+        )
+
     def handle(self, *args, **options):
 
-        messages = check_sanity(progress=True)
+        messages = check_sanity(progress=not options['no_progress_bar'])
 
         messages.log_messages()

--- a/src/documents/management/commands/document_thumbnails.py
+++ b/src/documents/management/commands/document_thumbnails.py
@@ -47,6 +47,12 @@ class Command(BaseCommand):
             help="Specify the ID of a document, and this command will only "
                  "run on this specific document."
         )
+        parser.add_argument(
+            "--no-progress-bar",
+            default=False,
+            action="store_true",
+            help="If set, the progress bar will not be shown"
+        )
 
     def handle(self, *args, **options):
         logging.getLogger().handlers[0].level = logging.ERROR
@@ -65,5 +71,7 @@ class Command(BaseCommand):
 
         with multiprocessing.Pool() as pool:
             list(tqdm.tqdm(
-                pool.imap_unordered(_process_document, ids), total=len(ids)
+                pool.imap_unordered(_process_document, ids),
+                total=len(ids),
+                disable=options['no_progress_bar']
             ))

--- a/src/documents/sanity_checker.py
+++ b/src/documents/sanity_checker.py
@@ -60,12 +60,7 @@ def check_sanity(progress=False):
     if lockfile in present_files:
         present_files.remove(lockfile)
 
-    if progress:
-        docs = tqdm(Document.objects.all())
-    else:
-        docs = Document.objects.all()
-
-    for doc in docs:
+    for doc in tqdm(Document.objects.all(), disable=not progress):
         # Check sanity of the thumbnail
         if not os.path.isfile(doc.thumbnail_path):
             messages.error(f"Thumbnail of document {doc.pk} does not exist.")

--- a/src/documents/tasks.py
+++ b/src/documents/tasks.py
@@ -20,13 +20,13 @@ def index_optimize():
     writer.commit(optimize=True)
 
 
-def index_reindex():
+def index_reindex(progress_bar_disable=False):
     documents = Document.objects.all()
 
     ix = index.open_index(recreate=True)
 
     with AsyncWriter(ix) as writer:
-        for document in tqdm.tqdm(documents):
+        for document in tqdm.tqdm(documents, disable=progress_bar_disable):
             index.update_document(writer, document)
 
 


### PR DESCRIPTION
The progress bar is relay not useful when we call the commands from a cron job.