### PR TITLE
Use gosu as it is less complicated than sudo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update \
 		imagemagick \
 		gettext \
 		tzdata \
-		sudo \
+		gosu \
 		# fonts for text file thumbnail generation
 		fonts-liberation \
 		# for Numpy
@@ -96,8 +96,8 @@ COPY src/ ./
 RUN addgroup --gid 1000 paperless \
 	&& useradd --uid 1000 --gid paperless --home-dir /usr/src/paperless paperless \
 	&& chown -R paperless:paperless ../ \
-	&& sudo -HEu paperless python3 manage.py collectstatic --clear --no-input \
-	&& sudo -HEu paperless python3 manage.py compilemessages
+	&& gosu paperless python3 manage.py collectstatic --clear --no-input \
+	&& gosu paperless python3 manage.py compilemessages
 
 VOLUME ["/usr/src/paperless/data", "/usr/src/paperless/media", "/usr/src/paperless/consume", "/usr/src/paperless/export"]
 ENTRYPOINT ["/sbin/docker-entrypoint.sh"]

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -34,7 +34,7 @@ initialize() {
 	chown -R paperless:paperless /tmp/paperless
     set -e
 
-    sudo -HEu paperless /sbin/docker-prepare.sh
+    gosu paperless /sbin/docker-prepare.sh
 }
 
 install_languages() {
@@ -85,7 +85,7 @@ initialize
 
 if [[ "$1" != "/"* ]]; then
 	echo Executing management command "$@"
-	exec sudo -HEu paperless python3 manage.py "$@"
+	exec gosu paperless python3 manage.py "$@"
 else
 	echo Executing "$@"
 	exec "$@"

--- a/docker/management_script.sh
+++ b/docker/management_script.sh
@@ -6,7 +6,7 @@ cd /usr/src/paperless/src/
 
 if [[ $(id -u) == 0 ]] ;
 then
-  sudo -HEu paperless python3 manage.py management_command "$@"
+  gosu paperless python3 manage.py management_command "$@"
 elif [[ $(id -un) == "paperless" ]] ;
 then
   python3 manage.py management_command "$@"


### PR DESCRIPTION
While investigating #879 I came across gosu which is used by postgres to run their process as a different user in the container after doing some setup as root. We might consider adapting it to avoid future problems with sudo. 