### PR TITLE
Remove PDF type attribute to fix macOS Safari native PDF viewer crashing

### DIFF
--- a/src-ui/src/app/components/document-detail/document-detail.component.html
+++ b/src-ui/src/app/components/document-detail/document-detail.component.html
@@ -139,7 +139,7 @@
                 <pdf-viewer [src]="previewUrl" [original-size]="false" [show-borders]="true" [show-all]="true" [(page)]="previewCurrentPage" [render-text-mode]="2" (after-load-complete)="pdfPreviewLoaded($event)"></pdf-viewer>
             </div>
             <ng-template #nativePdfViewer>
-                <object [data]="previewUrl | safe" type="application/pdf" class="preview-sticky" width="100%"></object>
+                <object [data]="previewUrl | safe" class="preview-sticky" width="100%"></object>
             </ng-template>
         </ng-container>
         <ng-container *ngIf="getContentType() == 'text/plain'">


### PR DESCRIPTION
@jonaswinkler sorry for the 1 line PR but figured I would do this so you dont have to think about it. 

This PR removes the `type` attribute of the PDF `object` tag which causes Safari macOS to crash when viewing PDFs, see https://github.com/jonaswinkler/paperless-ng/issues/65#issuecomment-778433328

One other thing Jonas, do you think we should change the "use native PDF" setting to default to `true` now? I think so, LMK I can add it here