### PR TITLE
Add print css for document list

### DIFF
--- a/src-ui/src/print.scss
+++ b/src-ui/src/print.scss
@@ -1,0 +1,30 @@
+@media print {
+  #sidebarMenu, .btn-toolbar {
+    display: none !important
+  }
+
+  .sticky-top {
+    display: none;
+  }
+
+  main, main.ml-sm-auto, main.mx-sm-auto {
+    margin-left: 0 !important;
+    margin-right: 0 !important;
+  }
+
+  main.col-lg-10 {
+    max-width: 100%;
+    flex-basis: 100%;
+    display: block;
+  }
+
+  .d-none.d-lg-table-cell { // always display ASN on print
+    display: table-cell !important;
+  }
+
+  app-document-list table {
+    thead th:first-child, tbody td:first-child { // hide checkboxes
+      display: none;
+    }
+  }
+}

--- a/src-ui/src/styles.scss
+++ b/src-ui/src/styles.scss
@@ -1,5 +1,6 @@
 @import "theme";
 @import "theme_dark";
+@import "print";
 @import "node_modules/bootstrap/scss/bootstrap";
 @import "~@ng-select/ng-select/themes/default.theme.css";
 


### PR DESCRIPTION
Allow printing of the document list in a clean way

* Hide sidebar, filter
* Use full width

See also https://github.com/jonaswinkler/paperless-ng/discussions/126

Preview of the print out

![print-css-for-documents](https://user-images.githubusercontent.com/1087128/118357147-ee152c00-b578-11eb-8797-231337d572ec.png)

How to generate a TOC

* Filter by the ASNs in you want to generate a ToC for using advanced search - `asn:[1 to 100]`
* Use the print function of your webbrowser

Known issues: 

* You still have to print each page manually, if the document spans more then one page
* Sorting needs to be fixed: https://github.com/jonaswinkler/paperless-ng/issues/975