### PR TITLE
Solving issue with search criteria 'maximum age' for some mail server

### DIFF
--- a/src/paperless_mail/mail.py
+++ b/src/paperless_mail/mail.py
@@ -75,9 +75,9 @@ def get_rule_action(rule):
 
 def make_criterias(rule):
     maximum_age = date.today() - timedelta(days=rule.maximum_age)
-    criterias = {
-        "date_gte": maximum_age
-    }
+    criterias = {}
+    if rule.maximum_age > 0:
+        criterias["date_gte"] = maximum_age    
     if rule.filter_from:
         criterias["from_"] = rule.filter_from
     if rule.filter_subject:


### PR DESCRIPTION
Some mail servers (mail.ru) do not support search criteria for the maximum age. By setting the maximum age to 0, it is possible to bypass the search criteria. This PR solves that problem.