### PR TITLE
Allow configuration from files

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -78,12 +78,34 @@ install_languages() {
 	done
 }
 
+load_secrets() {
+	# Look for any paperless variables with a '_FROM_FILE' suffix, and
+	# load the root variable with the content of the named file.  This
+	# will allow the use of bind-mounted files / secrets / etc rather than
+	# just sticking it in the environment.
+
+	for secret in ${!PAPERLESS_@} ; do
+
+		# no point if it's empty
+		[[ ! -z "${!secret}" ]] || continue
+
+		if [[ "${secret%_FROM_FILE}" != "$secret" ]] ; then
+			local target=${secret%_FROM_FILE}
+			echo "Loading secret into ${target} from ${!secret}..."
+			export "${target}"="$(cat ${!secret})"
+		fi
+
+	done
+}
+
 echo "Paperless-ng docker container starting..."
 
 # Install additional languages if specified
 if [[ ! -z "$PAPERLESS_OCR_LANGUAGES" ]]; then
 	install_languages "$PAPERLESS_OCR_LANGUAGES"
 fi
+
+load_secrets
 
 initialize
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -651,6 +651,27 @@ Docker-specific options
 These options don't have any effect in ``paperless.conf``. These options adjust
 the behavior of the docker container. Configure these in `docker-compose.env`.
 
+It is also possible to load specific environment variables from named files.
+You may wish to use this when using, e.g.,  Docker secrets.  To do this,
+simply set an environment variable with a ``_FROM_FILE`` suffix to the
+(fully-qualified) name of the file containing the value.
+
+For example, the suppose our database password "notyourpass" is stored in
+``/run/secrets/db``.  We would then set our configuration to include:
+
+    .. code:: bash
+
+        # this is set in our configuration
+        PAPERLESS_DBPASS_FROM_FILE=/run/secrets/db
+
+When the container is run it will then export into the running environment:
+
+    .. code:: bash
+
+        # this will be dynamically set by the container itself when run
+        PAPERLESS_DBPASS=notyourpass
+
+
 PAPERLESS_WEBSERVER_WORKERS=<num>
     The number of worker processes the webserver should spawn. More worker processes
     usually result in the front end to load data much quicker. However, each worker process


### PR DESCRIPTION
       
Sometimes we don't want to directly specify things like passwords directly in the environment.  Sometimes, sure, but quite often not.
    
Here we look for any environment variables named with a `PAPERLESS_`    prefix and `_FROM_FILE` suffix.  If found, we attempt to provision the    value of the root variable (e.g. without the `_FROM_FILE` suffix) from    the contents of the named file.