### PR TITLE
Simplify installation command

### DIFF
--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -116,9 +116,7 @@ performs all the steps described in :ref:`setup-docker_hub` automatically.
 
     .. code:: shell-session
 
-        $ wget https://raw.githubusercontent.com/jonaswinkler/paperless-ng/master/install-paperless-ng.sh
-        $ chmod +x install-paperless-ng.sh
-        $ ./install-paperless-ng.sh
+        $ curl -L https://raw.githubusercontent.com/jonaswinkler/paperless-ng/master/install-paperless-ng.sh | sh
 
 .. _setup-docker_hub:
 


### PR DESCRIPTION
The installation for docker is currently three separate commands, but it can be a single command if the user simply pipes to the sh interpreter directly. I know there are some who object to piping to sh from a URL, but the current method has no security benefit over piping directly to sh.