### PR TITLE
Added support for Luxembourgish (lb_LU) as an interface language

### DIFF
--- a/src-ui/angular.json
+++ b/src-ui/angular.json
@@ -27,7 +27,8 @@
 					"ru-RU": "src/locale/messages.ru_RU.xlf",
 					"es-ES": "src/locale/messages.es_ES.xlf",
 					"pl-PL": "src/locale/messages.pl_PL.xlf",
-					"sv-SE": "src/locale/messages.sv_SE.xlf"
+					"sv-SE": "src/locale/messages.sv_SE.xlf",
+					"lb-LU": "src/locale/messages.lb_LU.xlf"
 				}
 			},
 			"architect": {

--- a/src-ui/src/app/app.module.ts
+++ b/src-ui/src/app/app.module.ts
@@ -76,6 +76,7 @@ import localeRu from '@angular/common/locales/ru';
 import localeEs from '@angular/common/locales/es';
 import localePl from '@angular/common/locales/pl';
 import localeSv from '@angular/common/locales/sv';
+import localeLb from '@angular/common/locales/lb';
 
 
 registerLocaleData(localeFr)
@@ -90,6 +91,7 @@ registerLocaleData(localeRu)
 registerLocaleData(localeEs)
 registerLocaleData(localePl)
 registerLocaleData(localeSv)
+registerLocaleData(localeLb)
 
 @NgModule({
   declarations: [

--- a/src-ui/src/app/services/settings.service.ts
+++ b/src-ui/src/app/services/settings.service.ts
@@ -99,7 +99,8 @@ export class SettingsService {
       {code: "ru-ru", name: $localize`Russian`, englishName: "Russian", dateInputFormat: "dd.mm.yyyy"},
       {code: "es-es", name: $localize`Spanish`, englishName: "Spanish", dateInputFormat: "dd/mm/yyyy"},
       {code: "pl-pl", name: $localize`Polish`, englishName: "Polish", dateInputFormat: "dd.mm.yyyy"},
-      {code: "sv-se", name: $localize`Swedish`, englishName: "Swedish", dateInputFormat: "yyyy-mm-dd"}
+      {code: "sv-se", name: $localize`Swedish`, englishName: "Swedish", dateInputFormat: "yyyy-mm-dd"},
+      {code: "lb-lu", name: $localize`Luxembourgish`, englishName: "Luxembourgish", dateInputFormat: "dd.mm.yyyy"}
     ]
   }
 

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -313,6 +313,7 @@ LANGUAGES = [
     ("es-es", _("Spanish")),
     ("pl-pl", _("Polish")),
     ("sv-se", _("Swedish")),
+    ("lb-lu", _("Luxembourgish")),
 ]
 
 LOCALE_PATHS = [


### PR DESCRIPTION
Depends on #1153 to be merged as well.
I added the new language at the bottom of the different lists as they were not alphabetical.

I think it makes more sense for the languages to be ordered alphabetically by ISO code. Let me know if that would be ok for you, then I could do that in a second commit (or a separate PR, whatever you prefer).