### PR TITLE
Round dpi to fix tests with Pillow 8.3.1

### DIFF
--- a/src/paperless_tesseract/parsers.py
+++ b/src/paperless_tesseract/parsers.py
@@ -70,7 +70,7 @@ class RasterisedDocumentParser(DocumentParser):
         try:
             with Image.open(image) as im:
                 x, y = im.info['dpi']
-                return x
+                return round(x)
         except Exception as e:
             self.log(
                 'warning',


### PR DESCRIPTION
Pillow 8.3.1 returns floats for dpis, but OCRmyPDF still only accepts
integers. This then fails during command line parsing in OCRmyPDF.

Fix the tests by rounding dpis to restore the previous behavior.

Related OCRmyPDF issue: https://github.com/jbarlow83/OCRmyPDF/issues/802