### PR TITLE
update configuration docs for languages

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -257,6 +257,8 @@ PAPERLESS_OCR_LANGUAGE=<lang>
     languages enabled.
 
     Defaults to "eng".
+		
+		Note: If your language contains a '-' such as chi-sim, you must use chi_sim
 
 PAPERLESS_OCR_MODE=<mode>
     Tell paperless when and how to perform ocr on your documents. Four modes


### PR DESCRIPTION
Due to tesseract naming scheme, packages use '-' but the internal OCR uses '_' . This is to clarify in the documentation that this is the case for new users.