### PR TITLE
Add PAPERLESS_LOGOUT_REDIRECT_URL

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -233,6 +233,13 @@ PAPERLESS_HTTP_REMOTE_USER_HEADER_NAME=<str>
 
     Defaults to `HTTP_REMOTE_USER`.
 
+PAPERLESS_LOGOUT_REDIRECT_URL=<str>
+    URL to redirect the user to after a logout. This can be used together with
+    `PAPERLESS_ENABLE_HTTP_REMOTE_USER` to redirect the user back to the SSO
+    application's logout page.
+
+    Defaults to None, which disables this feature.
+
 .. _configuration-ocr:
 
 OCR settings

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -144,6 +144,7 @@ ROOT_URLCONF = 'paperless.urls'
 FORCE_SCRIPT_NAME = os.getenv("PAPERLESS_FORCE_SCRIPT_NAME")
 BASE_URL = (FORCE_SCRIPT_NAME or "") + "/"
 LOGIN_URL = BASE_URL + "accounts/login/"
+LOGOUT_REDIRECT_URL = os.getenv("PAPERLESS_LOGOUT_REDIRECT_URL")
 
 WSGI_APPLICATION = 'paperless.wsgi.application'
 ASGI_APPLICATION = "paperless.asgi.application"


### PR DESCRIPTION
Currently with external SSO (`PAPERLESS_ENABLE_HTTP_REMOTE_USER`), clicking "Logout" will tell the user that it was successful when in reality they are of course still logged in.

The new setting `PAPERLESS_LOGOUT_REDIRECT_URL` allows the user to be redirected to the real logout page (of the SSO app). The patch is almost trivial, because [the functionality already exists in Django](https://docs.djangoproject.com/en/3.2/ref/settings/#std:setting-LOGOUT_REDIRECT_URL).