### PR TITLE
fix(tika): adapt to Gotenberg 7 API

### DIFF
--- a/docker/compose/docker-compose.postgres-tika.yml
+++ b/docker/compose/docker-compose.postgres-tika.yml
@@ -75,10 +75,10 @@ services:
       PAPERLESS_TIKA_ENDPOINT: http://tika:9998
 
   gotenberg:
-    image: thecodingmachine/gotenberg
+    image: gotenberg/gotenberg:7
     restart: unless-stopped
     environment:
-      DISABLE_GOOGLE_CHROME: 1
+      CHROMIUM_DISABLE_ROUTES: 1
 
   tika:
     image: apache/tika

--- a/docker/compose/docker-compose.sqlite-tika.yml
+++ b/docker/compose/docker-compose.sqlite-tika.yml
@@ -64,10 +64,10 @@ services:
       PAPERLESS_TIKA_ENDPOINT: http://tika:9998
 
   gotenberg:
-    image: thecodingmachine/gotenberg
+    image: gotenberg/gotenberg:7
     restart: unless-stopped
     environment:
-      DISABLE_GOOGLE_CHROME: 1
+      CHROMIUM_DISABLE_ROUTES: 1
 
   tika:
     image: apache/tika

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -402,7 +402,7 @@ Tika settings
 #############
 
 Paperless can make use of `Tika <https://tika.apache.org/>`_ and
-`Gotenberg <https://thecodingmachine.github.io/gotenberg/>`_ for parsing and
+`Gotenberg <https://gotenberg.dev/>`_ for parsing and
 converting "Office" documents (such as ".doc", ".xlsx" and ".odt"). If you
 wish to use this, you must provide a Tika server and a Gotenberg server,
 configure their endpoints, and enable the feature.
@@ -444,10 +444,10 @@ requires are as follows:
         # ...
 
         gotenberg:
-            image: thecodingmachine/gotenberg
+            image: gotenberg/gotenberg:7
             restart: unless-stopped
             environment:
-                DISABLE_GOOGLE_CHROME: 1
+                CHROMIUM_DISABLE_ROUTES: 1
 
         tika:
             image: apache/tika

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -101,22 +101,22 @@ You may experience these errors when using the optional TIKA integration:
 
 .. code::
 
-    requests.exceptions.HTTPError: 504 Server Error: Gateway Timeout for url: http://gotenberg:3000/convert/office
+    requests.exceptions.HTTPError: 504 Server Error: Gateway Timeout for url: http://gotenberg:3000/forms/libreoffice/convert
 
-Gotenberg is a server that converts Office documents into PDF documents and has a default timeout of 10 seconds.
+Gotenberg is a server that converts Office documents into PDF documents and has a default timeout of 30 seconds.
 When conversion takes longer, Gotenberg raises this error.
 
-You can increase the timeout by configuring an environment variable for gotenberg (see also `here <https://thecodingmachine.github.io/gotenberg/#environment_variables.default_wait_timeout>`__).
+You can increase the timeout by configuring an environment variable for Gotenberg (see also `here <https://gotenberg.dev/docs/modules/api#properties>`__).
 If using docker-compose, this is achieved by the following configuration change in the ``docker-compose.yml`` file:
 
 .. code:: yaml
 
     gotenberg:
-        image: thecodingmachine/gotenberg
+        image: gotenberg/gotenberg:7
         restart: unless-stopped
         environment:
-            DISABLE_GOOGLE_CHROME: 1
-            DEFAULT_WAIT_TIMEOUT: 30
+            CHROMIUM_DISABLE_ROUTES: 1
+            API_PROCESS_TIMEOUT: 60
 
 Permission denied errors in the consumption directory
 #####################################################

--- a/scripts/start_services.sh
+++ b/scripts/start_services.sh
@@ -1,4 +1,4 @@
 docker run -p 5432:5432 -e POSTGRES_PASSWORD=password -v paperless_pgdata:/var/lib/postgresql/data -d postgres:13
 docker run -d -p 6379:6379 redis:latest
-docker run -p 3000:3000 -d thecodingmachine/gotenberg
+docker run -p 3000:3000 -d gotenberg/gotenberg:7
 docker run -p 9998:9998 -d apache/tika

--- a/src/paperless_tika/parsers.py
+++ b/src/paperless_tika/parsers.py
@@ -67,7 +67,7 @@ class TikaDocumentParser(DocumentParser):
     def convert_to_pdf(self, document_path, file_name):
         pdf_path = os.path.join(self.tempdir, "convert.pdf")
         gotenberg_server = settings.PAPERLESS_TIKA_GOTENBERG_ENDPOINT
-        url = gotenberg_server + "/convert/office"
+        url = gotenberg_server + "/forms/libreoffice/convert"
 
         self.log("info", f"Converting {document_path} to PDF as {pdf_path}")
         files = {"files": (file_name or os.path.basename(document_path),


### PR DESCRIPTION
# Description

This commit adapts to the latest breaking changes from Gotenberg 7. Changes as follows:

* Change from https://hub.docker.com/r/thecodingmachine/gotenberg to new official https://hub.docker.com/r/gotenberg/gotenberg/ docker repository
* Freeze the usage of the Gotenberg server to v7.x. Doing this prevents further breaking changes leaking in our code base
* Change endpoint from `/convert/office` to `/forms/libreoffice/convert` ([documentation](https://gotenberg.dev/docs/modules/libreoffice#convert))
* Adapt environment variables ([documentation](https://github.com/gotenberg/gotenberg/blame/cc1ad1668877dd8b1ef32624aae49094d58cd183/Makefile))
  * From `DISABLE_GOOGLE_CHROME` to `CHROMIUM_DISABLE_ROUTES`
  * From `DEFAULT_WAIT_TIMEOUT` to `API_PROCESS_TIMEOUT`

Let me know if you need more information or request a change. 

# Addresses Issues

#1250

# Tests Conducted

```bash
./compile-frontend.sh
docker build . -t paperlessG
```

Created a `docx` document with Libreoffice and imported it via the consume directory.

```bash
webserver_1  | [2021-08-27 06:24:13,104] [INFO] [paperless.management.consumer] Adding /usr/src/paperless/src/../consume/testdocument.docx to the task queue.
webserver_1  | 06:24:13 [Q] INFO Enqueued 1
webserver_1  | 06:24:13 [Q] INFO Process-1:7 processing [testdocument.docx]
webserver_1  | [2021-08-27 06:24:13,188] [INFO] [paperless.consumer] Consuming testdocument.docx
webserver_1  | [2021-08-27 06:24:13,200] [INFO] [paperless.parsing.tika] Sending /usr/src/paperless/src/../consume/testdocument.docx to Tika server
tika_1       | INFO  rmeta/text (autodetecting type)
webserver_1  | [2021-08-27 06:24:13,691] [INFO] [paperless.parsing.tika] Converting /usr/src/paperless/src/../consume/testdocument.docx to PDF as /tmp/paperless/paperless-sptrrp84/convert.pdf
gotenberg_1  | {"level":"info","ts":1630045455.1634862,"logger":"api","msg":"request handled","trace":"5cd6d0f9-f8f0-4f69-90a4-45fe4b3c22a8","remote_ip":"172.18.0.5","host":"gotenberg:3000","uri":"/forms/libreoffice/convert","method":"POST","path":"/forms/libreoffice/convert","referer":"","user_agent":"python-requests/2.26.0","status":200,"latency":1468509495,"latency_human":"1.468509495s","bytes_in":4407,"bytes_out":8295}
webserver_1  | [2021-08-27 06:24:16,809] [INFO] [paperless.consumer] Document 2021-08-27 testdocument consumption finished
webserver_1  | 06:24:16 [Q] INFO Process-1:7 stopped doing work
webserver_1  | 06:24:16 [Q] INFO Processed [testdocument.docx]
webserver_1  | 06:24:16 [Q] INFO recycled worker Process-1:7
webserver_1  | 06:24:16 [Q] INFO Process-1:9 ready for work at 136
```

![consumed](https://user-images.githubusercontent.com/5375334/131083893-f32e0ab3-0a75-4236-8944-a215448ce320.png)
