### PR TITLE
Fix PAPERLESS_TIKA_GOTENBERG_ENDPOINT in a/t/main.yml

### DIFF
--- a/ansible/tasks/main.yml
+++ b/ansible/tasks/main.yml
@@ -329,7 +329,7 @@
     - regexp: PAPERLESS_TIKA_ENDPOINT
       line: "PAPERLESS_TIKA_ENDPOINT={{ paperlessng_tika_endpoint }}"
     - regexp: PAPERLESS_TIKA_GOTENBERG_ENDPOINT
-      line: "PAPERLESS_TIKA_GOTENBERG_ENDPOINT={{ paperlessng_tika_endpoint }}"
+      line: "PAPERLESS_TIKA_GOTENBERG_ENDPOINT={{ paperlessng_tika_gotenberg_endpoint }}"
     # Software tweaks
     - regexp: PAPERLESS_TIME_ZONE
       line: "PAPERLESS_TIME_ZONE={{ paperlessng_time_zone }}"


### PR DESCRIPTION
This fixes the ansible role for installing paperless-ng where the config
item PAPERLESS_TIKA_GOTENBERG_ENDPOINT derived from the wrong ansible
variable "paperlessng_tika_endpoint".  This patch corrects that to
"paperlessng_tika_gotenberg_endpoint".