### PR TITLE
Allow specifying port through PAPERLESS_PORT environment variable

### DIFF
--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,6 +1,6 @@
 import os
 
-bind = '0.0.0.0:8000'
+bind = f'0.0.0.0:{os.getenv("PAPERLESS_PORT", 8000)}'
 workers = int(os.getenv("PAPERLESS_WEBSERVER_WORKERS", 2))
 worker_class = 'paperless.workers.ConfigurableWorker'
 timeout = 120

--- a/paperless.conf.example
+++ b/paperless.conf.example
@@ -5,6 +5,9 @@
 
 #PAPERLESS_DEBUG=false
 
+# Webserver configuration
+#PAPERLESS_PORT=8000
+
 # Required services
 
 #PAPERLESS_REDIS=redis://localhost:6379


### PR DESCRIPTION
While Docker containers have their own IP address namespace and port collisions are impossible to achieve, other container solutions share one.
Podman, for example, runs all containers in a pod under one namespace, which results in every port only being allowed to be assigned once. Having a default port in the image that cannot be changed can cause collisions and incompabilities.

This change allows setting a custom port for Gunicorn through the environment while keeping the default port as fallback to keep backwards compatibility.