### PR TITLE
Add loading indicator when document list reloading

### DIFF
--- a/src-ui/src/app/components/document-list/document-list.component.html
+++ b/src-ui/src/app/components/document-list/document-list.component.html
@@ -84,7 +84,7 @@
   <p>
     <ng-container *ngIf="list.isReloading">
       <div class="spinner-border spinner-border-sm mr-2" role="status"></div>
-      Loading...
+      <ng-container i18n>Loading...</ng-container>
     </ng-container>
     <span i18n *ngIf="list.selected.size > 0">{list.collectionSize, plural, =1 {Selected {{list.selected.size}} of one document} other {Selected {{list.selected.size}} of {{list.collectionSize || 0}} documents}}</span>
     <ng-container *ngIf="!list.isReloading">

--- a/src-ui/src/app/components/document-list/document-list.component.html
+++ b/src-ui/src/app/components/document-list/document-list.component.html
@@ -82,8 +82,14 @@
 
 <div class="d-flex justify-content-between align-items-center">
   <p>
+    <ng-container *ngIf="list.isReloading">
+      <div class="spinner-border spinner-border-sm mr-2" role="status"></div>
+      Loading...
+    </ng-container>
     <span i18n *ngIf="list.selected.size > 0">{list.collectionSize, plural, =1 {Selected {{list.selected.size}} of one document} other {Selected {{list.selected.size}} of {{list.collectionSize || 0}} documents}}</span>
-    <span i18n *ngIf="list.selected.size == 0">{list.collectionSize, plural, =1 {One document} other {{{list.collectionSize || 0}} documents}}</span>&nbsp;<span i18n *ngIf="isFiltered">(filtered)</span>
+    <ng-container *ngIf="!list.isReloading">
+      <span i18n *ngIf="list.selected.size == 0">{list.collectionSize, plural, =1 {One document} other {{{list.collectionSize || 0}} documents}}</span>&nbsp;<span i18n *ngIf="isFiltered">(filtered)</span>
+    </ng-container>
   </p>
   <ngb-pagination [pageSize]="list.currentPageSize" [collectionSize]="list.collectionSize" [(page)]="list.currentPage" [maxSize]="5"
   [rotate]="true" aria-label="Default pagination"></ngb-pagination>


### PR DESCRIPTION
This PR addresses feature request #1260 and adds a loading indicator (spinner + text) to the documents list while a filter / search is being processed. See video below.

@jonaswinkler you still out there buddy?

https://user-images.githubusercontent.com/4887959/132621027-b31da84e-3603-48db-8e2b-2f98fd94edb6.mov