### PR TITLE
Use Gotenberg v6 explicitly

### DIFF
--- a/docker/compose/docker-compose.postgres-tika.yml
+++ b/docker/compose/docker-compose.postgres-tika.yml
@@ -75,7 +75,7 @@ services:
       PAPERLESS_TIKA_ENDPOINT: http://tika:9998
 
   gotenberg:
-    image: thecodingmachine/gotenberg
+    image: thecodingmachine/gotenberg:6
     restart: unless-stopped
     environment:
       DISABLE_GOOGLE_CHROME: 1

--- a/docker/compose/docker-compose.sqlite-tika.yml
+++ b/docker/compose/docker-compose.sqlite-tika.yml
@@ -64,7 +64,7 @@ services:
       PAPERLESS_TIKA_ENDPOINT: http://tika:9998
 
   gotenberg:
-    image: thecodingmachine/gotenberg
+    image: thecodingmachine/gotenberg:6
     restart: unless-stopped
     environment:
       DISABLE_GOOGLE_CHROME: 1

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -451,7 +451,7 @@ requires are as follows:
         # ...
 
         gotenberg:
-            image: thecodingmachine/gotenberg
+            image: thecodingmachine/gotenberg:6
             restart: unless-stopped
             environment:
                 DISABLE_GOOGLE_CHROME: 1

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -112,7 +112,7 @@ If using docker-compose, this is achieved by the following configuration change 
 .. code:: yaml
 
     gotenberg:
-        image: thecodingmachine/gotenberg
+        image: thecodingmachine/gotenberg:6
         restart: unless-stopped
         environment:
             DISABLE_GOOGLE_CHROME: 1

--- a/scripts/start_services.sh
+++ b/scripts/start_services.sh
@@ -1,4 +1,4 @@
 docker run -p 5432:5432 -e POSTGRES_PASSWORD=password -v paperless_pgdata:/var/lib/postgresql/data -d postgres:13
 docker run -d -p 6379:6379 redis:latest
-docker run -p 3000:3000 -d thecodingmachine/gotenberg
+docker run -p 3000:3000 -d thecodingmachine/gotenberg:6
 docker run -p 9998:9998 -d apache/tika


### PR DESCRIPTION
Gotenberg released v7 about a month ago which uses different API paths.