### PR TITLE
Added hint to use Management Utilities

### DIFF
--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -406,7 +406,7 @@ the naming scheme.
 
 The command takes no arguments and processes all your documents at once.
 
-Learn how to Use :ref:`Management Utilities<Management utilities>`.
+Learn how to use :ref:`Management Utilities<Management utilities>`.
 
 
 .. _utilities-sanity-checker:


### PR DESCRIPTION
Hi,

referencing to this thread https://github.com/jonaswinkler/paperless-ng/discussions/749#discussioncomment-1444404.

Since a friend and me are running our first paperless-ng instances, we both didn't configured proper Filenames while importing the first documents. After configuring the env variable properly it worked out great for new files.

But I really had problems to get the old files renamed and didn't even know there are Management Utilities.

I decided it would be helpful for other users to add a hint about the Management Utilities in the document_renamer section, since it it linked from Stackoverflow and findable per Websearch.

Feel free to accept this change :)

If you need any further modification, just drop me a message.

Thanks for your great tool!

Best regards

Patrick