### PR TITLE
Update login.html to not autocapitalize username

### DIFF
--- a/src/documents/templates/registration/login.html
+++ b/src/documents/templates/registration/login.html
@@ -53,7 +53,7 @@
 			{% translate "Username" as i18n_username %}
 			{% translate "Password" as i18n_password %}
 			<label for="inputUsername" class="sr-only">{{ i18n_username }}</label>
-			<input type="text" name="username" id="inputUsername" class="form-control" placeholder="{{ i18n_username }}" required autofocus>
+			<input type="text" name="username" id="inputUsername" class="form-control" placeholder="{{ i18n_username }}" autocorrect="off" autocapitalize="none" required autofocus>
 			<label for="inputPassword" class="sr-only">{{ i18n_password }}</label>
 			<input type="password" name="password" id="inputPassword" class="form-control" placeholder="{{ i18n_password }}" required>
 			<button class="btn btn-lg btn-primary btn-block" type="submit">{% translate "Sign in" %}</button>


### PR DESCRIPTION
On iOS, when typing a username into the login form, the first character is capitalized by default. This will fix that behavior to the expected behavior of a lowercase username.

References:
https://stackoverflow.com/questions/5171764/how-do-you-turn-off-auto-capitalisation-in-html-form-fields-in-ios
https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/Attributes.html#//apple_ref/doc/uid/TP40008058-autocapitalize