### PR TITLE
add ansible role_name to fix ci

### DIFF
--- a/ansible/meta/main.yml
+++ b/ansible/meta/main.yml
@@ -5,6 +5,8 @@ galaxy_info:
   description: Bare-metal deployment of paperless-ng DMS
   license: license (GPLv3)
   min_ansible_version: 2.7
+  namespace: paperless_ng
+  role_name: paperless_ng
 
   platforms:
     - name: Debian


### PR DESCRIPTION
Current `Ansible Role` Action fails with error:
```
ERROR    Computed fully qualified role name of C0nsultant.ansible does not follow current galaxy requirements.
Please edit meta/main.yml and assure we can correctly determine full role name:
Traceback (most recent call last):

galaxy_info:
  File "/opt/hostedtoolcache/Python/3.10.1/x64/bin/molecule", line 8, in <module>
role_name: my_name  # if absent directory name hosting role is used instead
namespace: my_galaxy_namespace  # if absent, author is used instead
    sys.exit(main())
```
To fix, I added role_name and namespace explicitly.