### PR TITLE
Add API Scanning Setup section to scanners.rst

### DIFF
--- a/docs/scanners.rst
+++ b/docs/scanners.rst
@@ -98,3 +98,22 @@ On Android, you can use these applications in combination with one of the :ref:`
 
 .. _hannahswain: https://github.com/hannahswain
 .. _benjaminfrank: https://github.com/benjaminfrank
+
+API Scanning Setup
+==================
+
+This sections contains information on how to set up scanners to post directly to :ref:`Paperless API <api-file_uploads>`.
+
+Doxie Q2
+--------
+
+This part assumes your Doxie is connected to WiFi and you know it's IP.
+
+1. Open your Doxies web UI
+2. Navigate to *TODO ???* > Webhook
+3. Set the Webhook URL to ``https://[your-paperless-ng-instance]/api/documents/post_document/``
+4. Set the *TODO ??? something formfield ???* to ``document``
+5. Add the username and password *TODO elaborate on how*
+6. Save
+
+Congrats, you can now scan directly from your Doxie to your Paperless-ng instance!

--- a/docs/scanners.rst
+++ b/docs/scanners.rst
@@ -109,11 +109,11 @@ Doxie Q2
 
 This part assumes your Doxie is connected to WiFi and you know it's IP.
 
-1. Open your Doxies web UI
-2. Navigate to *TODO ???* > Webhook
-3. Set the Webhook URL to ``https://[your-paperless-ng-instance]/api/documents/post_document/``
-4. Set the *TODO ??? something formfield ???* to ``document``
-5. Add the username and password *TODO elaborate on how*
-6. Save
+1. Open your Doxie web UI by navigating to its IP address
+2. Navigate to Options -> Webhook
+3. Set the *URL* to ``https://[your-paperless-ng-instance]/api/documents/post_document/``
+4. Set the *File Parameter Name* to ``document``
+5. Add the username and password to the respective fields (Consider creating a user just for your Doxie)
+6. Click *Submit* at the bottom of the page
 
 Congrats, you can now scan directly from your Doxie to your Paperless-ng instance!


### PR DESCRIPTION
I've received a few messages asking me how to set up the Doxie Q2 with the API. This is why I think it would be beneficial to have the instructions listed directly in `scanners.rst`.

This PR contains the instructions for the Doxie Q2.

Let me know what you think! 🙂 