### PR TITLE
Dockerfile: Fix DOS EOL on shell scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update \
 	&& apt-get -y --no-install-recommends install \
   	# Basic dependencies
 		curl \
+		dos2unix \
 		gnupg \
 		imagemagick \
 		gettext \
@@ -73,7 +74,8 @@ RUN apt-get update \
 COPY docker/ ./docker/
 
 RUN cd docker \
-  && cp imagemagick-policy.xml /etc/ImageMagick-6/policy.xml \
+	&& dos2unix *.sh \
+	&& cp imagemagick-policy.xml /etc/ImageMagick-6/policy.xml \
 	&& mkdir /var/log/supervisord /var/run/supervisord \
 	&& cp supervisord.conf /etc/supervisord.conf \
 	&& cp docker-entrypoint.sh /sbin/docker-entrypoint.sh \

--- a/docker/install_management_commands.sh
+++ b/docker/install_management_commands.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 for command in document_archiver document_exporter document_importer mail_fetcher document_create_classifier document_index document_renamer document_retagger document_thumbnails document_sanity_checker manage_superuser;
 do
 	echo "installing $command..."


### PR DESCRIPTION
If the repo is checked out with git "autocrlf" enabled, the DOS EOLs cause the scripts to not be executable.
https://willi.am/blog/2016/08/11/docker-for-windows-dealing-with-windows-line-endings/ explains it.

I'm happy to move `dos2unix` into the relevant `RUN` command and purge it at the end of the `RUN`. I havent done that as this is a tiny program.